### PR TITLE
Fix Gravity pull method.

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/GravityLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/GravityLevelModifier.java
@@ -75,12 +75,13 @@ public class GravityLevelModifier implements LevelModifier {
       return;
     }
 
-    double vspeed = element.getSpeed().getY() * d;
+    double vspeed = element.vSpeed();
+    double update = strength * d;
     // If the element has not yet reached the maximal falling speed and the difference is still
     // larger than or equal than the strength, increment it. Otherwise, set the vertical speed to
     // maximal.
-    if ((max - vspeed) >= strength) {
-      element.getSpeed().setY(vspeed + strength);
+    if ((max - vspeed) >= update) {
+      element.getSpeed().setY(vspeed + update);
     } else {
       element.getSpeed().setY(max);
     }


### PR DESCRIPTION
Issue #101. The player jump height is way too inconsistent, sometime the
player even flies away. Traced this bug to the pull method of the Gravity
Level Modifier. The delta was not taken into account correctly when
updating the player's speed vector.

<bug,testing