### PR TITLE
Fixed settings logger functioning

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/Constants.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Constants.java
@@ -45,6 +45,7 @@ public final class Constants {
   public static final String LOGGING_SHOOTING = "Do you wish to track shooting?";
   public static final String LOGGING_ACTIVE = "Yes";
   public static final String LOGGING_DISABLED = "No";
+  public static final String SETTINGSCLOSE = "Close";
   
   // Defining the settings value tracking.
   public static boolean LOGGING_WANTMOVEMENT = true;

--- a/src/main/java/nl/tudelft/scrumbledore/Constants.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Constants.java
@@ -48,10 +48,10 @@ public final class Constants {
   public static final String SETTINGSCLOSE = "Close";
   
   // Defining the settings value tracking.
-  public static boolean LOGGING_WANTMOVEMENT = true;
-  public static boolean LOGGING_WANTINPUT = true;
-  public static boolean LOGGING_WANTSTARTSTOP = true;
-  public static boolean LOGGING_WANTSHOOTING = true;
+  public static boolean LOGGING_WANTMOVEMENT = false;
+  public static boolean LOGGING_WANTINPUT = false;
+  public static boolean LOGGING_WANTSTARTSTOP = false;
+  public static boolean LOGGING_WANTSHOOTING = false;
 
   // Defining text needed for the display of dialog and handling boxes within the user interface.
   public static final String GAMEWIN_DIALOG = "You beat the game, congratulations!";

--- a/src/main/java/nl/tudelft/scrumbledore/GUI.java
+++ b/src/main/java/nl/tudelft/scrumbledore/GUI.java
@@ -589,6 +589,13 @@ public class GUI extends Application {
     movementLogFalse.setToggleGroup(playerMovementGroup);
     movementToggleBox.getChildren().addAll(movementLogTrue, movementLogFalse);
 
+    // Arming initial buttons.
+    if (Constants.LOGGING_WANTMOVEMENT) {
+      movementLogTrue.setSelected(true);
+    } else {
+      movementLogFalse.setSelected(true);
+    }
+
     // Implementing the listener for the radio buttons above.
     playerMovementGroup.selectedToggleProperty().addListener(new ChangeListener<Toggle>() {
 
@@ -612,6 +619,13 @@ public class GUI extends Application {
     final RadioButton inputLogFalse = new RadioButton(Constants.LOGGING_DISABLED);
     inputLogFalse.setToggleGroup(playerInputGroup);
     inputToggleBox.getChildren().addAll(inputLogTrue, inputLogFalse);
+
+    // Arming initial buttons.
+    if (Constants.LOGGING_WANTINPUT) {
+      inputLogTrue.setSelected(true);
+    } else {
+      inputLogFalse.setSelected(true);
+    }
 
     // Implementing the listener for the radio buttons above.
     playerInputGroup.selectedToggleProperty().addListener(new ChangeListener<Toggle>() {
@@ -637,6 +651,12 @@ public class GUI extends Application {
     shootLogFalse.setToggleGroup(playerShootGroup);
     shootToggleBox.getChildren().addAll(shootLogTrue, shootLogFalse);
 
+    if (Constants.LOGGING_WANTSHOOTING) {
+      shootLogTrue.setSelected(true);
+    } else {
+      shootLogFalse.setSelected(true);
+    }
+
     // Implementing the listener for the radio buttons above.
     playerShootGroup.selectedToggleProperty().addListener(new ChangeListener<Toggle>() {
 
@@ -660,6 +680,12 @@ public class GUI extends Application {
     final RadioButton gameLogFalse = new RadioButton(Constants.LOGGING_DISABLED);
     gameLogFalse.setToggleGroup(gameLogGroup);
     gameLogBox.getChildren().addAll(gameLogTrue, gameLogFalse);
+
+    if (Constants.LOGGING_WANTSTARTSTOP) {
+      gameLogTrue.setSelected(true);
+    } else {
+      gameLogFalse.setSelected(true);
+    }
 
     // Implementing the listener for the radio buttons above.
     gameLogGroup.selectedToggleProperty().addListener(new ChangeListener<Toggle>() {

--- a/src/main/java/nl/tudelft/scrumbledore/GUI.java
+++ b/src/main/java/nl/tudelft/scrumbledore/GUI.java
@@ -34,8 +34,8 @@ import javafx.stage.WindowEvent;
  * @author Jesse Tilro
  * @author Niels Warnars
  */
-@SuppressWarnings({ "checkstyle:methodlength", "PMD.TooManyMethods", "PMD.NPathComplexity", 
-  "PMD.CyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity", "PMD.StdCyclomaticComplexity" })
+@SuppressWarnings({ "checkstyle:methodlength", "PMD.TooManyMethods", "PMD.NPathComplexity",
+    "PMD.CyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity", "PMD.StdCyclomaticComplexity" })
 public class GUI extends Application {
   private Game game;
   private StepTimer timer;
@@ -596,7 +596,7 @@ public class GUI extends Application {
           Toggle newToggle) {
         if (newToggle == movementLogTrue) {
           Constants.LOGGING_WANTMOVEMENT = true;
-        } else {
+        } else if (newToggle == movementLogFalse) {
           Constants.LOGGING_WANTMOVEMENT = false;
         }
       }
@@ -620,7 +620,7 @@ public class GUI extends Application {
           Toggle newToggle) {
         if (newToggle == inputLogTrue) {
           Constants.LOGGING_WANTINPUT = true;
-        } else {
+        } else if (newToggle == inputLogFalse) {
           Constants.LOGGING_WANTINPUT = false;
         }
       }
@@ -644,7 +644,7 @@ public class GUI extends Application {
           Toggle newToggle) {
         if (newToggle == shootLogTrue) {
           Constants.LOGGING_WANTSHOOTING = true;
-        } else {
+        } else if (newToggle == shootLogFalse) {
           Constants.LOGGING_WANTSHOOTING = false;
         }
       }
@@ -668,7 +668,7 @@ public class GUI extends Application {
           Toggle newToggle) {
         if (newToggle == gameLogTrue) {
           Constants.LOGGING_WANTSTARTSTOP = true;
-        } else {
+        } else if (newToggle == gameLogFalse) {
           Constants.LOGGING_WANTSTARTSTOP = false;
         }
       }

--- a/src/main/java/nl/tudelft/scrumbledore/GUI.java
+++ b/src/main/java/nl/tudelft/scrumbledore/GUI.java
@@ -562,7 +562,7 @@ public class GUI extends Application {
     Label gameStateLog = new Label(Constants.LOGGING_GAME_STARTSTOP);
 
     // Adding the exit button to go back to the game menu.
-    Button exitButton = new Button(Constants.EXITBTNLABEL);
+    Button exitButton = new Button(Constants.SETTINGSCLOSE);
 
     // Performing the handling of the settings exit button.
     exitButton.setOnAction(new EventHandler<ActionEvent>() {


### PR DESCRIPTION
Fixed the functioning of the logger, to ensure that the logging is disabled by default and only starts logging when it has been selected in the settings menu.  The settings menu now also correctly updates and sends desired logging queries.