### PR TITLE
Test sprite spritestore

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/GUI.java
+++ b/src/main/java/nl/tudelft/scrumbledore/GUI.java
@@ -18,6 +18,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.image.Image;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -242,8 +243,9 @@ public class GUI extends Application {
       spr = "player-right";
     }
 
-    painter.drawImage(sprites.getImage(spr), game.getCurrentLevel().getPlayer().getPosition()
-        .getX(), game.getCurrentLevel().getPlayer().getPosition().getY());
+    painter.drawImage(new Image(sprites.getPathFromID(spr)), 
+        game.getCurrentLevel().getPlayer().getPosition().getX(), 
+        game.getCurrentLevel().getPlayer().getPosition().getY());
   }
 
   /**
@@ -260,8 +262,8 @@ public class GUI extends Application {
     }
 
     for (Bubble currentBubble : bubbles) {
-      painter.drawImage(sprites.getImage("bubble"), currentBubble.getPosition().getX(),
-          currentBubble.getPosition().getY());
+      painter.drawImage(new Image(sprites.getPathFromID("bubble")), 
+          currentBubble.getPosition().getX(), currentBubble.getPosition().getY());
     }
   }
 
@@ -285,8 +287,8 @@ public class GUI extends Application {
       if (current.getMovementDirection().equals(NPCAction.MoveLeft)) {
         spr = "enemy-mighta-left";
       }
-      painter.drawImage(sprites.getImage(spr), current.getPosition().getX(), current.getPosition()
-          .getY());
+      painter.drawImage(new Image(sprites.getPathFromID(spr)), 
+          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 
@@ -300,8 +302,8 @@ public class GUI extends Application {
     // Placing the platform elements within the level.
     for (Platform current : game.getCurrentLevel().getPlatforms()) {
       // Painting the current platform image at the desired x and y location given by the vector.
-      painter.drawImage(sprites.getImage("wall-1"), current.getPosition().getX(), current
-          .getPosition().getY());
+      painter.drawImage(new Image(sprites.getPathFromID("wall-1")), 
+          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 
@@ -319,8 +321,8 @@ public class GUI extends Application {
     }
 
     for (Fruit current : fruits) {
-      painter.drawImage(sprites.getImage("fruit-banana"), current.getPosition().getX(), current
-          .getPosition().getY());
+      painter.drawImage(new Image(sprites.getPathFromID("fruit-banana")), 
+          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/Sprite.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Sprite.java
@@ -1,12 +1,10 @@
 package nl.tudelft.scrumbledore;
 
-import javafx.scene.image.Image;
-
 /**
  * Represents a sprite that can be drawn in the GUI as a visual representation of a LevelElement.
  * 
  * @author Jesse Tilro
- *
+ * @author Niels Warnars
  */
 public class Sprite {
 

--- a/src/main/java/nl/tudelft/scrumbledore/Sprite.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Sprite.java
@@ -75,14 +75,5 @@ public class Sprite {
   public String getPath() {
     return dir + id + "." + ext;
   }
-
-  /**
-   * Get a JavaFX Image instance for this sprite.
-   * 
-   * @return An Image instance.
-   */
-  public Image getImage() {
-    return new Image(getPath());
-  }
-
+  
 }

--- a/src/main/java/nl/tudelft/scrumbledore/SpriteStore.java
+++ b/src/main/java/nl/tudelft/scrumbledore/SpriteStore.java
@@ -84,14 +84,14 @@ public class SpriteStore {
   }
 
   /**
-   * Get an Image instance of the Sprite with the given ID.
+   * Get the path of a Sprite based on a given ID.
    * 
    * @param id
    *          The ID.
-   * @return An Image.
+   * @return The path of a Sprite
    */
-  public Image getImage(String id) {
-    return get(id).getImage();
+  public String getPathFromID(String id) {
+    return get(id).getPath();
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/SpriteStore.java
+++ b/src/main/java/nl/tudelft/scrumbledore/SpriteStore.java
@@ -3,14 +3,12 @@ package nl.tudelft.scrumbledore;
 import java.io.File;
 import java.util.ArrayList;
 
-import javafx.scene.image.Image;
-
 /**
  * The Sprite Store reads and creates Sprites from the file system and allows to easily select and
  * use them.
  * 
  * @author Jesse Tilro
- *
+ * @author Niels Warnars
  */
 public class SpriteStore {
 

--- a/src/test/java/nl/tudelft/scrumbledore/SpriteStoreTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/SpriteStoreTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
  * Test Suite for the Sprite Store class.
  * 
  * @author Jesse Tilro
- *
+ * @author Niels Warnars
  */
 public class SpriteStoreTest {
 
@@ -53,4 +53,13 @@ public class SpriteStoreTest {
     assertEquals(null, test.get("non_existant_sprite"));
   }
 
+  /**
+   * A valid path to a Sprite should be returned if the SpriteStore is queried
+   * for a given ID.
+   */
+  @Test
+  public void testGetPathFromID() {
+    SpriteStore test = new SpriteStore();
+    assertEquals("images/sprites/bubble.png", test.getPathFromID("bubble"));
+   }
 }

--- a/src/test/java/nl/tudelft/scrumbledore/SpriteTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/SpriteTest.java
@@ -1,11 +1,8 @@
 package nl.tudelft.scrumbledore;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
-
-import javafx.scene.image.Image;
 
 /**
  * Test Suite for the Sprite class.

--- a/src/test/java/nl/tudelft/scrumbledore/SpriteTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/SpriteTest.java
@@ -1,8 +1,11 @@
 package nl.tudelft.scrumbledore;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
+
+import javafx.scene.image.Image;
 
 /**
  * Test Suite for the Sprite class.
@@ -41,4 +44,5 @@ public class SpriteTest {
     String expectedPath = Constants.SPRITES_DIR + "file.ext";
     assertEquals(expectedPath, test.getPath());
   }
+
 }


### PR DESCRIPTION
Moves the creation of Image objects to the GUI and away from the Sprite / SpriteStore classes.
Adds test case for the SpriteStore::getPathFromID method.

<testing,organisation