### PR TITLE
Fix logger findbugs issues

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/Logger.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Logger.java
@@ -2,8 +2,9 @@ package nl.tudelft.scrumbledore;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -34,11 +35,20 @@ public final class Logger {
   @SuppressWarnings("checkstyle:methodlength")
   public static void start() {
     loggingDir = new File(Constants.RESOURCES_DIR + Constants.LOGGER_DIR);
-
-    if (!loggingDir.exists()) {
-      loggingDir.mkdir();
+    
+    try {
+      if (!loggingDir.exists()) {
+        boolean result = loggingDir.mkdir();
+        
+        // Throw an IOException if the logging directory could not be made.
+        if (!result) {
+            throw new IOException();
+        }
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-
+    
     try {
       // Fetching the current date for the creation of the file and parsing it to allow for simple
       // formatting.
@@ -48,7 +58,8 @@ public final class Logger {
       String desiredFileName = "Session-" + simpleFormat.format(currentDate) + ".log";
       loggingFile = new File(Constants.RESOURCES_DIR + Constants.LOGGER_DIR + desiredFileName);
 
-      BufferedWriter buffWriter = new BufferedWriter(new FileWriter(loggingFile));
+      BufferedWriter buffWriter = new BufferedWriter(
+          new OutputStreamWriter(new FileOutputStream(loggingFile), "UTF-8"));
       buffWriter.write("--------------------SCRUMBLEDORE LOGGING FILE");
 
       // Closing the stream as both an optimization and as a bug removing technique, as closing it
@@ -70,7 +81,8 @@ public final class Logger {
   public static void log(String toLog) {
     if (started) {
       try {
-        BufferedWriter buffWriter = new BufferedWriter(new FileWriter(loggingFile, true));
+        BufferedWriter buffWriter = new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(loggingFile, true), "UTF-8"));
 
         // Adds a new line to ensure that each log item takes up a new line.
         buffWriter.newLine();


### PR DESCRIPTION
- Throws an IOException when a logging directory could not be created
- Replaces the FileWriter with an OutputStreamWriter to support custom encodings.

<organisation,feature