### PR TITLE
Fix Fruit Warping and Picking Up

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/BubbleActionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/BubbleActionsLevelModifier.java
@@ -29,7 +29,7 @@ public class BubbleActionsLevelModifier implements LevelModifier {
     for (Bubble bub : bubbles) {
       if (bub.getLifetime() <= 0) {
         if (bub.hasNPC()) {
-          enemies.add(new NPC(bub.getPosition().clone(), 
+          enemies.add(new NPC(bub.getPosition().clone(),
               new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE)));
           enemyBubbles.remove(bub);
         }
@@ -47,24 +47,10 @@ public class BubbleActionsLevelModifier implements LevelModifier {
           bub.getSpeed().setX(Constants.BUBBLE_SPEED);
         }
 
-        warp(bub);
-        
         bub.clearActions();
       }
     }
 
-  }
-
-  /**
-   * When a Bubble leaves the level from the top, it should warp to the bottom of the level.
-   * 
-   * @param bubble
-   *          The Bubble to be warped.
-   */
-  private void warp(Bubble bubble) {
-    if (bubble.posY() <= -bubble.height() / 2) {
-      bubble.getPosition().setY(Constants.LEVELY + bubble.height() / 2);
-    }
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/CollisionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/CollisionsLevelModifier.java
@@ -66,7 +66,7 @@ public class CollisionsLevelModifier implements LevelModifier {
           if (collision.collidingFromTop() && fruit.vSpeed() > 0) {
             kinetics.stopVertically(fruit);
             kinetics.snapTop(fruit, platform);
-            fruit.setIsPickable(true);
+            fruit.setPickable(true);
           }
         }
       }
@@ -246,8 +246,8 @@ public class CollisionsLevelModifier implements LevelModifier {
 
           // If a bubble contains an enemy, drop a fruit.
           if (collision.colliding() && bubble.hasNPC()) {
-            Fruit newFruit = new Fruit(bubble.getPosition().clone(), new Vector(
-                Constants.BLOCKSIZE, Constants.BLOCKSIZE));
+            Fruit newFruit = new Fruit(bubble.getPosition().clone(),
+                new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
             fruits.add(newFruit);
             level.getEnemyBubbles().remove(bubble);
             level.getBubbles().remove(bubble);

--- a/src/main/java/nl/tudelft/scrumbledore/CollisionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/CollisionsLevelModifier.java
@@ -57,6 +57,19 @@ public class CollisionsLevelModifier implements LevelModifier {
    */
   protected void detectFruitPlatform(Level level, double delta) {
     for (Fruit fruit : level.getFruits()) {
+      // To prevent the player from instantaneously picking up fruit.
+      boolean pickable = true;
+      for (Player player : level.getPlayers()) {
+        Collision playerCollision = new Collision(fruit, player, delta);
+        if (playerCollision.colliding()) {
+          pickable = false;
+        }
+      }
+      // Since becoming pickable can't be undone.
+      if (pickable) {
+        fruit.setPickable(pickable);
+      }
+
       for (Platform platform : level.getPlatforms()) {
         // Check if platform is in collision range.
         if (platform.inBoxRangeOf(fruit, Constants.COLLISION_RADIUS)) {
@@ -66,7 +79,6 @@ public class CollisionsLevelModifier implements LevelModifier {
           if (collision.collidingFromTop() && fruit.vSpeed() > 0) {
             kinetics.stopVertically(fruit);
             kinetics.snapTop(fruit, platform);
-            fruit.setPickable(true);
           }
         }
       }

--- a/src/main/java/nl/tudelft/scrumbledore/Fruit.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Fruit.java
@@ -19,12 +19,11 @@ public class Fruit extends LevelElement {
    */
   public Fruit(Vector position, Vector size) {
     super(position, size);
-    
+
     setGravity(true);
     pickable = false;
   }
 
-  
   /**
    * Dummy HashCode method to satisfy code quality tools.
    */
@@ -32,8 +31,7 @@ public class Fruit extends LevelElement {
   public int hashCode() {
     return 0;
   }
-  
-  
+
   /**
    * Check whether a given object is equal to this instance.
    * 
@@ -45,24 +43,21 @@ public class Fruit extends LevelElement {
   public boolean equals(Object other) {
     if (other instanceof Fruit) {
       Fruit that = (Fruit) other;
-      return (this.getPosition().equals(that.getPosition()) 
+      return (this.getPosition().equals(that.getPosition())
           && this.getSize().equals(that.getSize()));
     }
-    
+
     return false;
   }
-
 
   /**
    * Get the value of a fruit.
    * 
-   * @return
-   *        The value of a fruit
+   * @return The value of a fruit
    */
   public int getValue() {
     return value;
   }
-
 
   /**
    * Set the value of a fruit.
@@ -73,20 +68,23 @@ public class Fruit extends LevelElement {
   public void setValue(int value) {
     this.value = value;
   }
-  
+
   /**
    * Return whether the fruit instance is pickable or not.
+   * 
    * @return Boolean pickable.
    */
   public Boolean isPickable() {
     return pickable;
   }
-  
+
   /**
    * Setting whether the fruit instance is pickable.
-   * @param bool true or false.
+   * 
+   * @param bool
+   *          true or false.
    */
-  public void setIsPickable(Boolean bool) {
+  public void setPickable(Boolean bool) {
     pickable = bool;
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/KineticsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/KineticsLevelModifier.java
@@ -37,6 +37,7 @@ public class KineticsLevelModifier implements LevelModifier {
   private void updateFruit(Level level, double d) {
     for (Fruit fruit : level.getFruits()) {
       addSpeed(fruit, d);
+      warpVertically(fruit);
     }
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/KineticsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/KineticsLevelModifier.java
@@ -51,6 +51,7 @@ public class KineticsLevelModifier implements LevelModifier {
   private void updateNPC(Level level, double d) {
     for (NPC npc : level.getNPCs()) {
       addSpeed(npc, d);
+      warpVertically(npc);
     }
   }
 
@@ -66,10 +67,7 @@ public class KineticsLevelModifier implements LevelModifier {
     ArrayList<Player> players = level.getPlayers();
     for (Player player : players) {
       addSpeed(player, d);
-
-      if (player.posY() + player.height() >= Constants.LEVELY) {
-        player.getPosition().setY(player.height() / -2);
-      }
+      warpVertically(player);
 
       if (Constants.LOGGING_WANTMOVEMENT) {
         // Logging the movement of the player within the level to the session log.
@@ -97,6 +95,7 @@ public class KineticsLevelModifier implements LevelModifier {
     for (Bubble bubble : bubbles) {
       addSpeed(bubble, d);
       applyFriction(bubble, d);
+      warpVertically(bubble);
     }
   }
 
@@ -176,6 +175,21 @@ public class KineticsLevelModifier implements LevelModifier {
    */
   public void stopHorizontally(LevelElement element) {
     element.getSpeed().setX(0);
+  }
+
+  /**
+   * Warp a Level Element through the vertical boundaries of the level.
+   * 
+   * @param element
+   *          The Level Element to be warped.
+   */
+  public void warpVertically(LevelElement element) {
+    double offset = element.width() / 2;
+    if (element.posY() < -offset) {
+      element.getPosition().setY(Constants.LEVELY + offset);
+    } else if (element.posY() > Constants.LEVELY + offset) {
+      element.getPosition().setY(-offset);
+    }
   }
 
   /**

--- a/src/main/java/nl/tudelft/scrumbledore/NPCLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/NPCLevelModifier.java
@@ -32,10 +32,6 @@ public class NPCLevelModifier implements LevelModifier {
 
       npc.clearActions();
 
-      if (npc.posY() >= Constants.LEVELY + npc.height() / 2) {
-        npc.getPosition().setY(-npc.height() / 2);
-      }
-
     }
 
   }

--- a/src/test/java/nl/tudelft/scrumbledore/CollisionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/CollisionsLevelModifierTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +20,7 @@ public class CollisionsLevelModifierTest {
   private KineticsLevelModifier klm;
   private ScoreCounter sc;
   private CollisionsLevelModifier clm;
-  
+
   /**
    * Set up mock objects and an CollisionsLevelModifier instance.
    */
@@ -27,10 +28,10 @@ public class CollisionsLevelModifierTest {
   public void setUp() {
     klm = mock(KineticsLevelModifier.class);
     sc = mock(ScoreCounter.class);
-    
+
     clm = new CollisionsLevelModifier(klm, sc);
   }
-  
+
   /**
    * Test the CollisionsLevelModifier constructor and the getter methods.
    */
@@ -38,7 +39,7 @@ public class CollisionsLevelModifierTest {
   public void testCollisionsLevelModifier() {
     KineticsLevelModifier klm = new KineticsLevelModifier();
     ScoreCounter sc = new ScoreCounter();
-    
+
     CollisionsLevelModifier clm = new CollisionsLevelModifier(klm, sc);
     assertEquals(klm, clm.getKinetics());
     assertEquals(sc, clm.getScore());
@@ -55,7 +56,7 @@ public class CollisionsLevelModifierTest {
     Level level = new Level();
     level.addElement(fruit);
     level.addElement(platform);
-   
+
     clm.detectFruitPlatform(level, 1);
     verify(klm).stopVertically(fruit);
     verify(klm).snapTop(fruit, platform);
@@ -69,16 +70,16 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 32), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
     npc.getSpeed().setY(4);
-    
+
     Level level = new Level();
     level.addElement(platform);
     level.addElement(npc);
-    
-    clm.detectNPCPlatform(level, 1);   
+
+    clm.detectNPCPlatform(level, 1);
     verify(klm).stopVertically(npc);
     verify(klm).snapTop(npc, platform);
   }
-  
+
   /**
    * Test the collision between a platform and an NPC colliding from the left.
    */
@@ -87,17 +88,17 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
     npc.getSpeed().setX(4);
-    
+
     Level level = new Level();
     level.addElement(platform);
     level.addElement(npc);
-    
-    clm.detectNPCPlatform(level, 1);   
+
+    clm.detectNPCPlatform(level, 1);
     verify(klm).stopHorizontally(npc);
     verify(klm).snapLeft(npc, platform);
     assertTrue(npc.hasAction(NPCAction.MoveLeft));
   }
-  
+
   /**
    * Test the collision between a platform and an NPC colliding from the right.
    */
@@ -106,17 +107,17 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(33, 0), new Vector(32, 32));
     npc.getSpeed().setX(-4);
-    
+
     Level level = new Level();
     level.addElement(platform);
     level.addElement(npc);
-    
-    clm.detectNPCPlatform(level, 1);   
+
+    clm.detectNPCPlatform(level, 1);
     verify(klm).stopHorizontally(npc);
     verify(klm).snapRight(npc, platform);
     assertTrue(npc.hasAction(NPCAction.MoveRight));
   }
-  
+
   /**
    * Test the collision between a platform and a player colliding from the top.
    */
@@ -125,16 +126,16 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 32), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     player.getSpeed().setY(4);
-    
+
     Level level = new Level();
     level.addElement(player);
     level.addElement(platform);
 
-    clm.detectPlayerPlatform(level, 1);   
+    clm.detectPlayerPlatform(level, 1);
     verify(klm).stopVertically(player);
     verify(klm).snapTop(player, platform);
   }
-  
+
   /**
    * Test the collision between a platform and a player colliding from the bottom.
    */
@@ -143,16 +144,16 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     Player player = new Player(new Vector(0, 33), new Vector(32, 32));
     player.getSpeed().setY(-4);
-    
+
     Level level = new Level();
     level.addElement(player);
     level.addElement(platform);
 
-    clm.detectPlayerPlatform(level, 1);   
+    clm.detectPlayerPlatform(level, 1);
     verify(klm).stopVertically(player);
     verify(klm).snapBottom(player, platform);
   }
-  
+
   /**
    * Test the collision between a platform and a player colliding from the left.
    */
@@ -160,17 +161,17 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerPlatformFromLeft() {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
-    
+
     player.getSpeed().setX(4);
-    
+
     Level level = new Level();
     level.addElement(player);
     level.addElement(platform);
 
-    clm.detectPlayerPlatform(level, 1);   
+    clm.detectPlayerPlatform(level, 1);
     verify(klm).stopHorizontally(player);
   }
-  
+
   /**
    * Test the collision between a platform and a bubble colliding from the left.
    */
@@ -178,16 +179,16 @@ public class CollisionsLevelModifierTest {
   public void testDetectBubblePlatformFromLeft() {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(0, 0), new Vector(32, 32));
-        
+
     Level level = new Level();
     level.addElement(bubble);
     level.addElement(platform);
-    
+
     clm.detectBubblePlatform(level, 1);
     verify(klm).snapLeft(bubble, platform);
     assertEquals(bubble.hSpeed(), -Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a bubble and a player colliding from the top.
    */
@@ -196,16 +197,16 @@ public class CollisionsLevelModifierTest {
     Bubble bubble = new Bubble(new Vector(0, 32), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     player.getSpeed().setY(4);
-    
+
     Level level = new Level();
     level.addElement(player);
     level.addElement(bubble);
 
-    clm.detectPlayerBubble(level, 1);   
+    clm.detectPlayerBubble(level, 1);
     verify(klm).snapTop(player, bubble);
     assertEquals(-Constants.PLAYER_JUMP, player.vSpeed(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a bubble and a bubble colliding.
    */
@@ -214,7 +215,7 @@ public class CollisionsLevelModifierTest {
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble2 = new Bubble(new Vector(0, 0), new Vector(32, 32));
-    
+
     bubble.getSpeed().setX(2);
     bubble2.getSpeed().setX(4);
 
@@ -223,7 +224,7 @@ public class CollisionsLevelModifierTest {
     level.addElement(bubble);
     level.addElement(bubble2);
 
-    clm.detectPlayerBubble(level, 1);   
+    clm.detectPlayerBubble(level, 1);
     assertEquals(Constants.BUBBLE_BOUNCE, bubble.hSpeed(), Constants.DOUBLE_PRECISION);
     assertEquals(-Constants.BUBBLE_BOUNCE, bubble2.hSpeed(), Constants.DOUBLE_PRECISION);
   }
@@ -236,7 +237,7 @@ public class CollisionsLevelModifierTest {
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble2 = new Bubble(new Vector(32, 0), new Vector(32, 32));
-    
+
     bubble.getSpeed().setX(2);
     bubble2.getSpeed().setX(4);
 
@@ -245,11 +246,11 @@ public class CollisionsLevelModifierTest {
     level.addElement(bubble);
     level.addElement(bubble2);
 
-    clm.detectPlayerBubble(level, 1);   
+    clm.detectPlayerBubble(level, 1);
     assertEquals(-Constants.BUBBLE_BOUNCE, bubble.hSpeed(), Constants.DOUBLE_PRECISION);
     assertEquals(Constants.BUBBLE_BOUNCE, bubble2.hSpeed(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a bubble and an enemy.
    */
@@ -257,13 +258,13 @@ public class CollisionsLevelModifierTest {
   public void testDetectBubbleEnemy() {
     Bubble bubble = new Bubble(new Vector(0, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 32), new Vector(32, 32));
-  
+
     Level level = new Level();
     level.addElement(bubble);
     level.addElement(npc);
-    
+
     assertEquals(0, level.getFruits().size());
-    clm.detectBubbleEnemy(level, 1);   
+    clm.detectBubbleEnemy(level, 1);
     assertEquals(0, level.getNPCs().size());
   }
 
@@ -274,13 +275,13 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerFruit() {
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     Fruit fruit = new Fruit(new Vector(0, 32), new Vector(32, 32));
-    fruit.setIsPickable(true);
-    
+    fruit.setPickable(true);
+
     Level level = new Level();
     level.addElement(player);
-    level.addElement(fruit);  
-    
-    clm.detectPlayerFruit(level, 1);   
+    level.addElement(fruit);
+
+    clm.detectPlayerFruit(level, 1);
     assertEquals(0, level.getFruits().size());
     verify(sc).updateScore(100);
   }
@@ -292,13 +293,13 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerEnemy() {
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 32), new Vector(32, 32));
-  
+
     Level level = new Level();
     level.addElement(player);
     level.addElement(npc);
-    
+
     assertTrue(player.isAlive());
-    clm.detectPlayerEnemy(level, 1);   
+    clm.detectPlayerEnemy(level, 1);
     assertFalse(player.isAlive());
   }
 

--- a/src/test/java/nl/tudelft/scrumbledore/KineticsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/KineticsLevelModifierTest.java
@@ -138,6 +138,32 @@ public class KineticsLevelModifierTest {
   }
 
   /**
+   * When a Level Element has gotten outside the bottom of the level and is subsequently being
+   * warped, it should reappear just outside the top of the level with the same X coordinate.
+   */
+  @Test
+  public void testWarpVerticallyBottomToTop() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setY(Constants.LEVELY + 17);
+    kinetics.warpVertically(el);
+    assertEquals(-16, el.posY(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When a Level Element has gotten outside the top of the level and is subsequently being warped,
+   * it should reappear just outside the bottom of the level with the same X coordinate.
+   */
+  @Test
+  public void testWarpVerticallyTopToBottom() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setY(-17);
+    kinetics.warpVertically(el);
+    assertEquals(Constants.LEVELY + 16, el.posY(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
    * The LevelElement should be correctly snapped the left side of another one using the snapLeft
    * method.
    */


### PR DESCRIPTION
Resolves Issue #144.

Implemented a single method for warping Level Elements, since we were
repeating that code and distributing the functionality over different
classes. Now also works two ways!

Fix the fruit picking up feature. It was not possible to pickup a piece of
fruit while still falling. Since a piece of fruit can be falling
infinitely after being created in above a warp hole, I changed this to
being pickable after the first time untouching every player.

<bug,organisation,testing,feature
