### PR TITLE
Fix killing enemy from above.

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
@@ -48,6 +48,7 @@ public class CollisionsLevelModifier implements LevelModifier {
     detectPlayerFruit(level, delta);
     detectPlayerEnemy(level, delta);
     detectBubbleEnemy(level, delta);
+    detectBubbleBubble(level, delta);
     detectNPCPlatform(level, delta);
   }
 
@@ -271,32 +272,6 @@ public class CollisionsLevelModifier implements LevelModifier {
           }
         }
       }
-
-      for (Bubble bubble : bubbles) {
-        if (bubble.inBoxRangeOf(player, Constants.COLLISION_RADIUS)) {
-          Collision collision = new Collision(player, bubble, delta);
-          if (collision.collidingFromTop() && player.vSpeed() > 0) {
-            player.getSpeed().setY(-Constants.PLAYER_JUMP);
-            kinetics.snapTop(player, bubble);
-            break;
-          }
-        }
-
-        for (Bubble other : bubbles) {
-          if (!other.equals(bubble) && other.inBoxRangeOf(bubble, Constants.COLLISION_RADIUS)) {
-            Collision collision = new Collision(bubble, other, delta);
-            if (collision.colliding()) {
-              if (other.posX() < bubble.posX()) {
-                other.getSpeed().setX(-Constants.BUBBLE_BOUNCE);
-                bubble.getSpeed().setX(Constants.BUBBLE_BOUNCE);
-              } else {
-                other.getSpeed().setX(Constants.BUBBLE_BOUNCE);
-                bubble.getSpeed().setX(-Constants.BUBBLE_BOUNCE);
-              }
-            }
-          }
-        }
-      }
     }
   }
 
@@ -306,7 +281,7 @@ public class CollisionsLevelModifier implements LevelModifier {
    * @param level
    *          The Level.
    * @param delta
-   *          The steps passed since this method wat last executed.
+   *          The steps passed since this method was last executed.
    */
   protected void detectBubbleEnemy(Level level, double delta) {
     ArrayList<NPC> enemies = level.getNPCs();
@@ -329,6 +304,40 @@ public class CollisionsLevelModifier implements LevelModifier {
 
             if (Constants.isLoggingWantEnemy()) {
               Logger.getInstance().log("An enemy was encapsulated by a bubble.");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Detect and handle collisions between Bubbles.
+   * 
+   * @param level
+   *          The level to be modified.
+   * @param delta
+   *          The number of steps passed since this method was last executed.
+   */
+  protected void detectBubbleBubble(Level level, double delta) {
+    ArrayList<Bubble> bubbles = new ArrayList<Bubble>();
+
+    // To prevent a race condition when many bubbles are shot rapidly
+    for (Bubble bubble : level.getBubbles()) {
+      bubbles.add(bubble);
+    }
+
+    for (Bubble bubble : bubbles) {
+      for (Bubble other : bubbles) {
+        if (!other.equals(bubble) && other.inBoxRangeOf(bubble, Constants.COLLISION_RADIUS)) {
+          Collision collision = new Collision(bubble, other, delta);
+          if (collision.colliding()) {
+            if (other.posX() < bubble.posX()) {
+              other.getSpeed().setX(-Constants.BUBBLE_BOUNCE);
+              bubble.getSpeed().setX(Constants.BUBBLE_BOUNCE);
+            } else {
+              other.getSpeed().setX(Constants.BUBBLE_BOUNCE);
+              bubble.getSpeed().setX(-Constants.BUBBLE_BOUNCE);
             }
           }
         }

--- a/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
@@ -11,16 +11,6 @@ import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.game.ScoreCounter;
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.CollisionsLevelModifier;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.KineticsLevelModifier;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.NPCAction;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test suite for the CollisionsLevelModifier class.
@@ -184,7 +174,7 @@ public class CollisionsLevelModifierTest {
     clm.detectPlayerPlatform(level, 1);
     verify(klm).stopHorizontally(player);
   }
-  
+
   /**
    * Test the collision between a platform and a player colliding from the right.
    */
@@ -219,7 +209,7 @@ public class CollisionsLevelModifierTest {
     verify(klm).snapBottom(bubble, platform);
     assertEquals(bubble.vSpeed(), Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a platform and a bubble colliding from the left.
    */
@@ -253,7 +243,7 @@ public class CollisionsLevelModifierTest {
     verify(klm).snapRight(bubble, platform);
     assertEquals(bubble.hSpeed(), Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a bubble and a player colliding from the top.
    */
@@ -271,7 +261,7 @@ public class CollisionsLevelModifierTest {
     verify(klm).snapTop(player, bubble);
     assertEquals(-Constants.PLAYER_JUMP, player.vSpeed(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the collision between a bubble containing an NPC and a player colliding from the top.
    */
@@ -279,7 +269,7 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerBubbleWithNPCFromTop() {
     Bubble bubble = new Bubble(new Vector(0, 32), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
-    
+
     bubble.setHasNPC(true);
     player.getSpeed().setY(4);
 
@@ -288,8 +278,7 @@ public class CollisionsLevelModifierTest {
     level.addElement(bubble);
 
     clm.detectPlayerBubble(level, 1);
-    verify(klm).snapTop(player, bubble);
-    assertEquals(-Constants.PLAYER_JUMP, player.vSpeed(), Constants.DOUBLE_PRECISION);
+    assertFalse(level.getBubbles().contains(bubble));
   }
 
   /**
@@ -309,7 +298,7 @@ public class CollisionsLevelModifierTest {
     level.addElement(bubble);
     level.addElement(bubble2);
 
-    clm.detectPlayerBubble(level, 1);
+    clm.detectBubbleBubble(level, 1);
     assertEquals(Constants.BUBBLE_BOUNCE, bubble.hSpeed(), Constants.DOUBLE_PRECISION);
     assertEquals(-Constants.BUBBLE_BOUNCE, bubble2.hSpeed(), Constants.DOUBLE_PRECISION);
   }
@@ -331,7 +320,7 @@ public class CollisionsLevelModifierTest {
     level.addElement(bubble);
     level.addElement(bubble2);
 
-    clm.detectPlayerBubble(level, 1);
+    clm.detectBubbleBubble(level, 1);
     assertEquals(-Constants.BUBBLE_BOUNCE, bubble.hSpeed(), Constants.DOUBLE_PRECISION);
     assertEquals(Constants.BUBBLE_BOUNCE, bubble2.hSpeed(), Constants.DOUBLE_PRECISION);
   }


### PR DESCRIPTION
Fixed killing the enemy from above. There were some weird nested loops in
the collision detection, containing some old code that made the player
bounce on top of the bubble regardless of whether it was holding an enemy.
This was probably due to an incorrectly resolved merge conflict.

Resolves issue #178.

<bug