### PR TITLE
Fix all CheckStyle and PMD errors

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -16,9 +16,6 @@
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
-		<accessrules>
-			<accessrule kind="accessible" pattern="javafx/**"/>
-		</accessrules>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>

--- a/src/main/java/nl/tudelft/scrumbledore/game/SinglePlayerGame.java
+++ b/src/main/java/nl/tudelft/scrumbledore/game/SinglePlayerGame.java
@@ -32,13 +32,6 @@ public class SinglePlayerGame extends Game {
   }
 
   /**
-   * Turn this Game's Levels into Single Player Game Levels by removing the second Player.
-   */
-  private void makeLevelsSinglePlayer() {
-
-  }
-
-  /**
    * Make new Levels for this Game.
    * 
    * @return A list of Levels.

--- a/src/test/java/nl/tudelft/scrumbledore/game/GameTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/GameTest.java
@@ -10,7 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.game.Game;
 import nl.tudelft.scrumbledore.level.Fruit;
 import nl.tudelft.scrumbledore.level.Level;
 import nl.tudelft.scrumbledore.level.Vector;

--- a/src/test/java/nl/tudelft/scrumbledore/game/MultiPlayerGameTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/MultiPlayerGameTest.java
@@ -1,6 +1,10 @@
 package nl.tudelft.scrumbledore.game;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
+
+import org.junit.Test;
 
 import nl.tudelft.scrumbledore.level.Level;
 
@@ -15,6 +19,16 @@ public class MultiPlayerGameTest extends GameTest {
   @Override
   protected Game make(ArrayList<Level> levels) {
     return new MultiPlayerGame(levels);
+  }
+
+  /**
+   * The MultiPlayerGame should make levels with at least two players.
+   */
+  @Test
+  public void testMakeLevels() {
+    Game game = new MultiPlayerGame();
+    ArrayList<Level> levels = game.makeLevels();
+    assertTrue(levels.get(0).getPlayers().size() > 1);
   }
 
 }

--- a/src/test/java/nl/tudelft/scrumbledore/game/MultiPlayerGameTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/MultiPlayerGameTest.java
@@ -2,8 +2,6 @@ package nl.tudelft.scrumbledore.game;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.game.Game;
-import nl.tudelft.scrumbledore.game.MultiPlayerGame;
 import nl.tudelft.scrumbledore.level.Level;
 
 /**

--- a/src/test/java/nl/tudelft/scrumbledore/game/SinglePlayerGameTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/SinglePlayerGameTest.java
@@ -1,6 +1,10 @@
 package nl.tudelft.scrumbledore.game;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
+
+import org.junit.Test;
 
 import nl.tudelft.scrumbledore.level.Level;
 
@@ -15,6 +19,16 @@ public class SinglePlayerGameTest extends GameTest {
   @Override
   protected Game make(ArrayList<Level> levels) {
     return new SinglePlayerGame(levels);
+  }
+
+  /**
+   * The SinglePlayerGame should make levels with only one player.
+   */
+  @Test
+  public void testMakeLevels() {
+    Game game = new SinglePlayerGame();
+    ArrayList<Level> levels = game.makeLevels();
+    assertEquals(1, levels.get(0).getPlayers().size());
   }
 
 }

--- a/src/test/java/nl/tudelft/scrumbledore/game/SinglePlayerGameTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/SinglePlayerGameTest.java
@@ -2,8 +2,6 @@ package nl.tudelft.scrumbledore.game;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.game.Game;
-import nl.tudelft.scrumbledore.game.SinglePlayerGame;
 import nl.tudelft.scrumbledore.level.Level;
 
 /**

--- a/src/test/java/nl/tudelft/scrumbledore/level/BubbleActionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/BubbleActionsLevelModifierTest.java
@@ -7,12 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.BubbleAction;
-import nl.tudelft.scrumbledore.level.BubbleActionsLevelModifier;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for the Bubble Actions Level Modifier class.

--- a/src/test/java/nl/tudelft/scrumbledore/level/BubbleTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/BubbleTest.java
@@ -8,10 +8,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.BubbleAction;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for the Bubble class.

--- a/src/test/java/nl/tudelft/scrumbledore/level/CollisionDirectionTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/CollisionDirectionTest.java
@@ -11,11 +11,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Collision;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for the Collision class.
@@ -54,7 +49,7 @@ public class CollisionDirectionTest {
    * @param expectedRight
    *          Expected outcome of the collision from top check.
    */
-  public CollisionDirectionTest(Vector collider, Vector collidee, Vector colliderSpeed, 
+  public CollisionDirectionTest(Vector collider, Vector collidee, Vector colliderSpeed,
       boolean expectedTop, boolean expectedBottom, boolean expectedLeft, boolean expectedRight) {
     this.expectedTop = expectedTop;
     this.expectedBottom = expectedBottom;
@@ -116,34 +111,32 @@ public class CollisionDirectionTest {
   public static Collection<Object[]> data() {
     Collection<Object[]> input = new ArrayList<Object[]>();
     // Same position should not classify as a collision from any direction.
-    input.add(new Object[] {
-        new Vector(0, 0), new Vector(0, 0), new Vector(0, 0), false, false, false, false });
+    input.add(new Object[] { new Vector(0, 0), new Vector(0, 0), new Vector(0, 0), false, false,
+        false, false });
 
     // Touching within collision precision.
     // Touching Top.
-    input.add(new Object[] {
-        new Vector(33, 32), new Vector(32, 64), new Vector(0, 0), true, false, false, false });
-    input.add(new Object[] {
-        new Vector(32, 32 - Constants.COLLISION_PRECISION), new Vector(32, 64), new Vector(0, 0), 
-        false, false, false, false });
+    input.add(new Object[] { new Vector(33, 32), new Vector(32, 64), new Vector(0, 0), true, false,
+        false, false });
+    input.add(new Object[] { new Vector(32, 32 - Constants.COLLISION_PRECISION), new Vector(32, 64),
+        new Vector(0, 0), false, false, false, false });
     // Touching Left.
-    input.add(new Object[] {
-        new Vector(0, 32), new Vector(32, 32), new Vector(0, 0), false, false, true, false });
-    input.add(new Object[] {
-        new Vector(0 - Constants.COLLISION_PRECISION, 32), new Vector(32, 32), new Vector(0, 0), 
-        false, false, false, false });
+    input.add(new Object[] { new Vector(0, 32), new Vector(32, 32), new Vector(0, 0), false, false,
+        true, false });
+    input.add(new Object[] { new Vector(0 - Constants.COLLISION_PRECISION, 32), new Vector(32, 32),
+        new Vector(0, 0), false, false, false, false });
 
     // Anticipation of predicted collision.
     // From Top.
-    input.add(new Object[] {
-        new Vector(32, 25), new Vector(32, 64), new Vector(0, 8), true, false, false, false });
-    input.add(new Object[] {
-        new Vector(32, 20), new Vector(32, 64), new Vector(0, 8), false, false, false, false });
-    input.add(new Object[] {
-        new Vector(0, 31), new Vector(32, 64), new Vector(0, 8), false, false, false, false });
+    input.add(new Object[] { new Vector(32, 25), new Vector(32, 64), new Vector(0, 8), true, false,
+        false, false });
+    input.add(new Object[] { new Vector(32, 20), new Vector(32, 64), new Vector(0, 8), false, false,
+        false, false });
+    input.add(new Object[] { new Vector(0, 31), new Vector(32, 64), new Vector(0, 8), false, false,
+        false, false });
     // From Left.
-    input.add(new Object[] {
-        new Vector(0, 32), new Vector(48, 32), new Vector(20, 0), false, false, true, false });
+    input.add(new Object[] { new Vector(0, 32), new Vector(48, 32), new Vector(20, 0), false, false,
+        true, false });
 
     return input;
   }

--- a/src/test/java/nl/tudelft/scrumbledore/level/CollisionTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/CollisionTest.java
@@ -10,12 +10,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import nl.tudelft.scrumbledore.level.Collision;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
-
 /**
  * Test Suite for the Collision class.
  * 

--- a/src/test/java/nl/tudelft/scrumbledore/level/FruitTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/FruitTest.java
@@ -1,15 +1,10 @@
 package nl.tudelft.scrumbledore.level;
 
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
-
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test case for the Fruit class.
@@ -24,23 +19,23 @@ public class FruitTest {
   @Test
   public void testFruit() {
     Fruit fruit = new Fruit(new Vector(0, 0), new Vector(32, 32));
-   
+
     assertEquals(new Vector(0, 0), fruit.getPosition());
     assertEquals(new Vector(32, 32), fruit.getSize());
     assertTrue(fruit.hasGravity());
   }
-  
+
   /**
    * Test the get/setValue methods.
    */
   @Test
   public void testGetSetValue() {
     Fruit fruit = new Fruit(new Vector(0, 0), new Vector(32, 32));
-    
+
     fruit.setValue(42);
     assertEquals(42, fruit.getValue());
   }
-  
+
   /**
    * Test dummy hashCode method.
    */
@@ -48,8 +43,9 @@ public class FruitTest {
   public void testHashCode() {
     Fruit fruit = new Fruit(new Vector(0, 0), new Vector(32, 32));
     assertEquals(0, fruit.hashCode());
- 
+
   }
+
   /**
    * Test the equals method with two the same objects.
    */
@@ -57,10 +53,10 @@ public class FruitTest {
   public void testEqualsTrue() {
     Fruit fruit1 = new Fruit(new Vector(0, 0), new Vector(32, 32));
     Fruit fruit2 = new Fruit(new Vector(0, 0), new Vector(32, 32));
-   
+
     assertEquals(fruit1, fruit2);
   }
-  
+
   /**
    * Test the equals method with two different objects.
    */
@@ -68,10 +64,10 @@ public class FruitTest {
   public void testEqualsFalse() {
     Fruit fruit1 = new Fruit(new Vector(0, 0), new Vector(32, 32));
     Fruit fruit2 = new Fruit(new Vector(1, 1), new Vector(32, 32));
-   
+
     assertFalse(fruit1.equals(fruit2));
   }
-  
+
   /**
    * Test the equals method with two different object classes.
    */
@@ -79,7 +75,7 @@ public class FruitTest {
   public void testEqualsOtherObject() {
     Fruit fruit = new Fruit(new Vector(0, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
-   
+
     assertFalse(fruit.equals(npc));
   }
 

--- a/src/test/java/nl/tudelft/scrumbledore/level/GravityTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/GravityTest.java
@@ -6,11 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.GravityLevelModifier;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for Gravity class.

--- a/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
@@ -7,15 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.KineticsLevelModifier;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Testing the Kinetics class.

--- a/src/test/java/nl/tudelft/scrumbledore/level/LevelElementTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/LevelElementTest.java
@@ -9,8 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for LevelElement class.
@@ -134,62 +132,61 @@ public abstract class LevelElementTest {
     assertEquals(5, l1.distance(l2), Constants.DOUBLE_PRECISION);
   }
 
-  
   /**
    * Test for the inRadiusRangeOf method.
    */
-  @Test 
+  @Test
   public void testInRadiusRangeOfTrue() {
     LevelElement l1 = make(new Vector(0, 0), size);
     LevelElement l2 = make(new Vector(0, 8), size);
-    
+
     assertTrue(l1.inRadiusRangeOf(l2, 8));
   }
-  
+
   /**
    * Test for the inRadiusRangeOf method.
    */
-  @Test 
+  @Test
   public void testInRadiusRangeOfFalse() {
     LevelElement l1 = make(new Vector(0, 0), size);
     LevelElement l2 = make(new Vector(0, 9), size);
-    
+
     assertFalse(l1.inRadiusRangeOf(l2, 8));
   }
-  
+
   /**
    * Test for the inRadiusRangeOf method.
    */
-  @Test 
+  @Test
   public void testInBoxRangeOfTrue() {
     LevelElement l1 = make(new Vector(0, 0), size);
     LevelElement l2 = make(new Vector(0, 8), size);
-    
+
     assertTrue(l1.inBoxRangeOf(l2, 8));
   }
-  
+
   /**
    * Test for the inRadiusRangeOf method.
    */
-  @Test 
+  @Test
   public void testInBoxRangeOfFalse() {
     LevelElement l1 = make(new Vector(0, 0), size);
     LevelElement l2 = make(new Vector(0, 9), size);
-    
+
     assertFalse(l1.inBoxRangeOf(l2, 8));
   }
-  
+
   /**
    * Test the posX and posY methods.
    */
   @Test
   public void testPos() {
     LevelElement l1 = make(new Vector(42, 21), size);
-   
+
     assertEquals(42, l1.posX(), Constants.DOUBLE_PRECISION);
     assertEquals(21, l1.posY(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test width() method.
    */
@@ -198,7 +195,7 @@ public abstract class LevelElementTest {
     LevelElement l1 = make(new Vector(42, 21), new Vector(16, 32));
     assertEquals(16, l1.width(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the height() method.
    */
@@ -207,7 +204,7 @@ public abstract class LevelElementTest {
     LevelElement l1 = make(position, new Vector(16, 32));
     assertEquals(32, l1.height(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the vSpeed and hSpeed methods.
    */
@@ -220,7 +217,7 @@ public abstract class LevelElementTest {
     assertEquals(5, l1.hSpeed(), Constants.DOUBLE_PRECISION);
     assertEquals(7, l1.vSpeed(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Test the hFric and vFric methods.
    */
@@ -233,7 +230,7 @@ public abstract class LevelElementTest {
     assertEquals(5, l1.hFric(), Constants.DOUBLE_PRECISION);
     assertEquals(7, l1.vFric(), Constants.DOUBLE_PRECISION);
   }
-  
+
   /**
    * Cleaning up test properties after testing.
    */

--- a/src/test/java/nl/tudelft/scrumbledore/level/LevelParserTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/LevelParserTest.java
@@ -11,13 +11,6 @@ import java.util.Scanner;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.LevelParser;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test suite for the LevelParser class.
@@ -158,30 +151,29 @@ public class LevelParserTest {
     assertEquals(new Vector(B_ONE, B_ONE), lp.getBlockPosition(0, 0));
     assertEquals(new Vector(B_TWO, B_TWO), lp.getBlockPosition(1, 1));
   }
-  
+
   /**
-   * Test whether the getLevels method returns the desired levels. 
+   * Test whether the getLevels method returns the desired levels.
    */
   @Test
   public void testGetLevels() {
     LevelParser lp = new LevelParser("src/main/resources/test");
     ArrayList<Level> levels = lp.getLevels();
 
+    Platform platform = new Platform(new Vector(0, 0),
+        new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
+    Player player = new Player(new Vector(0, 0),
+        new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
 
-    Platform platform = new Platform(new Vector(0, 0), 
-        new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
-    Player player = new Player(new Vector(0, 0), 
-        new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
-    
     // Check whether two test levels are available
     assertEquals(2, levels.size());
-    
+
     // Check whether level 1 contains a platform and level 2 doesn't
     assertEquals(platform, levels.get(0).getPlatforms().get(0));
     assertEquals(new ArrayList<Platform>(), levels.get(1).getPlatforms());
-    
+
     // Check whether level 1 contains a player and level 2 doesn't
-    assertEquals(0, levels.get(0).getPlayers().size());    
+    assertEquals(0, levels.get(0).getPlayers().size());
     assertEquals(player, levels.get(1).getPlayers().get(0));
   }
 }

--- a/src/test/java/nl/tudelft/scrumbledore/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/LevelTest.java
@@ -6,14 +6,6 @@ import java.util.ArrayList;
 
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.Vector;
-
 /**
  * Test case for the Level class.
  * 
@@ -23,47 +15,42 @@ public class LevelTest {
   private final Vector basicVt = new Vector(0, 0);
 
   /**
-   * Test case in which the addElement is tested
-   * using only one moving element.
+   * Test case in which the addElement is tested using only one moving element.
    */
   @Test
   public void testAddElementNPCs() {
     Level level = new Level();
     Fruit fr = new Fruit(basicVt, basicVt);
     NPC npc = new NPC(basicVt, basicVt);
-    
+
     level.addElement(fr);
     level.addElement(npc);
-    
-    ArrayList<NPC> npcs = level.getNPCs(); 
+
+    ArrayList<NPC> npcs = level.getNPCs();
     assertEquals(npcs.size(), 1);
     assertEquals(npcs.get(0).getClass(), NPC.class);
   }
 
-  
   /**
-   * Test case in which the addElement is tested
-   * using only one platform object.
+   * Test case in which the addElement is tested using only one platform object.
    */
   @Test
   public void testAddElementPlatforms() {
     Level level = new Level();
     Platform p1 = new Platform(basicVt, basicVt);
     Platform p2 = new Platform(basicVt, basicVt);
-    
+
     level.addElement(p1);
     level.addElement(p2);
-    
+
     ArrayList<Platform> platforms = level.getPlatforms();
     assertEquals(platforms.size(), 2);
     assertEquals(platforms.get(0).getClass(), Platform.class);
     assertEquals(platforms.get(1).getClass(), Platform.class);
   }
-  
 
   /**
-   * Test case in which the addElement is tested
-   * using a player object.
+   * Test case in which the addElement is tested using a player object.
    */
   @Test
   public void testAddElementPlayer() {
@@ -75,20 +62,18 @@ public class LevelTest {
     assertEquals(level.getPlayers().get(0), testPlayer);
   }
 
-
   /**
-   * Test case in which the addElement is tested
-   * using Fruit objects.
+   * Test case in which the addElement is tested using Fruit objects.
    */
   @Test
   public void testAddElementFruits() {
     Level level = new Level();
     Fruit f1 = new Fruit(basicVt, basicVt);
     Fruit f2 = new Fruit(basicVt, basicVt);
-    
+
     level.addElement(f1);
     level.addElement(f2);
-    
+
     ArrayList<Fruit> fruits = level.getFruits();
     assertEquals(fruits.size(), 2);
     assertEquals(fruits.get(0).getClass(), Fruit.class);
@@ -96,22 +81,20 @@ public class LevelTest {
   }
 
   /**
-   * Test case in which the addElement is tested
-   * using Bubble objects.
+   * Test case in which the addElement is tested using Bubble objects.
    */
   @Test
   public void testAddElementBubbles() {
     Level level = new Level();
     Bubble b1 = new Bubble(basicVt, basicVt);
     Bubble b2 = new Bubble(basicVt, basicVt);
-    
+
     level.addElement(b1);
     level.addElement(b2);
-    
+
     ArrayList<Bubble> bubbles = level.getBubbles();
     assertEquals(bubbles.size(), 2);
     assertEquals(bubbles.get(0).getClass(), Bubble.class);
     assertEquals(bubbles.get(1).getClass(), Bubble.class);
   }
 }
-

--- a/src/test/java/nl/tudelft/scrumbledore/level/NPCTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/NPCTest.java
@@ -7,12 +7,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.NPCAction;
-import nl.tudelft.scrumbledore.level.Vector;
-
 /**
  * Test suite for the NPC class.
  * 
@@ -23,7 +17,7 @@ import nl.tudelft.scrumbledore.level.Vector;
 public class NPCTest extends LevelElementTest {
 
   private NPC npc;
-  
+
   /**
    * Set the NPC field to a new NPC instance to use as a test object.
    */
@@ -31,15 +25,15 @@ public class NPCTest extends LevelElementTest {
   public void setUp() {
     npc = new NPC(new Vector(0, 0), new Vector(0, 0));
   }
-  
+
   @Override
   public LevelElement make(Vector position, Vector size) {
     return new NPC(position, size);
   }
 
   /**
-   * When a new NPC element is created, initially it should have gravity 
-   * and have the correct position and size.
+   * When a new NPC element is created, initially it should have gravity and have the correct
+   * position and size.
    */
   @Test
   public void testConstuctor() {
@@ -47,7 +41,7 @@ public class NPCTest extends LevelElementTest {
     assertEquals(new Vector(0, 0), npc.getSize());
     assertTrue(npc.hasGravity());
   }
-  
+
   /**
    * When an NPC action is added to a bubble's action queue, a call to hasAction for that action
    * should return true.
@@ -89,7 +83,7 @@ public class NPCTest extends LevelElementTest {
     npc.removeAction(NPCAction.MoveLeft);
     assertFalse(npc.hasAction(NPCAction.MoveLeft));
   }
-  
+
   /**
    * The stubbed method hashCode should just return zero (line coverage).
    */
@@ -97,7 +91,7 @@ public class NPCTest extends LevelElementTest {
   public void testHashCode() {
     assertEquals(0, npc.hashCode());
   }
-  
+
   /**
    * Two NPC instances with the same position and size should be considered equal.
    */
@@ -126,7 +120,7 @@ public class NPCTest extends LevelElementTest {
     Fruit fruit = new Fruit(npc.getPosition(), npc.getSize());
     assertFalse(npc.equals(fruit));
   }
-  
+
   /**
    * Test the lastMove field getter/setter.
    */

--- a/src/test/java/nl/tudelft/scrumbledore/level/PlatformTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/PlatformTest.java
@@ -6,25 +6,20 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.Platform;
-import nl.tudelft.scrumbledore.level.Vector;
-
 /**
  * Test suite for the Platform class.
  * 
  * @author Niels Warnars
  */
 public class PlatformTest {
-  
+
   /**
-   * Test the dummy hashcode method of the Platform class and verify 
-   * that 0 should be returned.
+   * Test the dummy hashcode method of the Platform class and verify that 0 should be returned.
    */
   @Test
   public void testHashCode() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
-    
+
     assertEquals(0, platform.hashCode());
   }
 
@@ -34,7 +29,7 @@ public class PlatformTest {
   @Test
   public void testPlatform() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
-    
+
     assertEquals(new Vector(0, 0), platform.getPosition());
     assertEquals(new Vector(32, 32), platform.getSize());
     assertFalse(platform.isPassable());
@@ -47,7 +42,7 @@ public class PlatformTest {
   public void testEqualsTrue() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     Platform platformExpected = new Platform(new Vector(0, 0), new Vector(32, 32));
-    
+
     assertEquals(platformExpected, platform);
   }
 
@@ -59,10 +54,10 @@ public class PlatformTest {
     Platform p1 = new Platform(new Vector(0, 0), new Vector(32, 32));
     Platform p2 = new Platform(new Vector(0, 0), new Vector(32, 32));
     p2.setPassable(true);
-    
+
     assertFalse(p1.equals(p2));
   }
-  
+
   /**
    * Test the equals method with two different objects.
    */
@@ -70,10 +65,10 @@ public class PlatformTest {
   public void testEqualsOtherObject() {
     Platform platform = new Platform(new Vector(21, 21), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
-    
+
     assertFalse(platform.equals(npc));
   }
-  
+
   /**
    * Test the get and set method of the isPassable attribute.
    */
@@ -81,7 +76,7 @@ public class PlatformTest {
   public void testIsPassable() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     platform.setPassable(true);
-    
+
     assertTrue(platform.isPassable());
   }
 

--- a/src/test/java/nl/tudelft/scrumbledore/level/PlayerActionTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/PlayerActionTest.java
@@ -4,71 +4,55 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.level.PlayerAction;
-
 /**
  * Test suite for the Player Action enum.
  * 
  * @author Niels Warnars
  */
 public class PlayerActionTest {
-  
+
   /**
-   * Test the invertAction method with a given
-   * MoveRight action. 
-   * Expected outcome: MoveStop.
+   * Test the invertAction method with a given MoveRight action. Expected outcome: MoveStop.
    */
   @Test
   public final void testInvertActionMoveRight() {
-    PlayerAction result = 
-        PlayerAction.invertAction(PlayerAction.MoveRight);
+    PlayerAction result = PlayerAction.invertAction(PlayerAction.MoveRight);
     assertEquals(PlayerAction.MoveStop, result);
   }
 
   /**
-   * Test the invertAction method with a given
-   * MoveLeft action.
-   * Expected outcome: MoveStop.
+   * Test the invertAction method with a given MoveLeft action. Expected outcome: MoveStop.
    */
   @Test
   public final void testInvertActionMoveLeft() {
-    PlayerAction result = 
-        PlayerAction.invertAction(PlayerAction.MoveLeft);
+    PlayerAction result = PlayerAction.invertAction(PlayerAction.MoveLeft);
     assertEquals(PlayerAction.MoveStop, result);
   }
-  
+
   /**
-   * Test the invertAction method with a given
-   * Shoot action.
-   * Expected outcome: ShootStop.
+   * Test the invertAction method with a given Shoot action. Expected outcome: ShootStop.
    */
   @Test
   public final void testInvertActionShoot() {
-    PlayerAction result = 
-        PlayerAction.invertAction(PlayerAction.Shoot);
+    PlayerAction result = PlayerAction.invertAction(PlayerAction.Shoot);
     assertEquals(PlayerAction.ShootStop, result);
   }
-  
+
   /**
-   * Test the invertAction method with an unsupported 
-   * action.
-   * Expected outcome: null.
+   * Test the invertAction method with an unsupported action. Expected outcome: null.
    */
   @Test
   public final void testInvertActionUnsupported() {
-    PlayerAction result = 
-        PlayerAction.invertAction(PlayerAction.Jump);
+    PlayerAction result = PlayerAction.invertAction(PlayerAction.Jump);
     assertEquals(null, result);
   }
 
   /**
-   * Test the invertAction method with null given.
-   * Expected outcome: null.
+   * Test the invertAction method with null given. Expected outcome: null.
    */
   @Test
   public final void testInvertActionNull() {
-    PlayerAction result = 
-        PlayerAction.invertAction(null);
+    PlayerAction result = PlayerAction.invertAction(null);
     assertEquals(null, result);
   }
 }

--- a/src/test/java/nl/tudelft/scrumbledore/level/PlayerActionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/PlayerActionsLevelModifierTest.java
@@ -7,11 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.PlayerAction;
-import nl.tudelft.scrumbledore.level.PlayerActionsLevelModifier;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for the Player Actions Level Modifier class.

--- a/src/test/java/nl/tudelft/scrumbledore/level/PlayerTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/PlayerTest.java
@@ -7,12 +7,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.PlayerAction;
-import nl.tudelft.scrumbledore.level.Vector;
-
 /**
  * Test Suite for the Player class.
  * 

--- a/src/test/java/nl/tudelft/scrumbledore/level/VectorTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/VectorTest.java
@@ -7,9 +7,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.level.Fruit;
-import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Test Suite for Vector Class.

--- a/src/test/java/nl/tudelft/scrumbledore/sprite/AnimatedSpriteTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/sprite/AnimatedSpriteTest.java
@@ -10,9 +10,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import nl.tudelft.scrumbledore.sprite.AnimatedSprite;
-import nl.tudelft.scrumbledore.sprite.Sprite;
-
 /**
  * Test Suite for the Animated Sprite class.
  * 

--- a/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteStoreTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteStoreTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.sprite.SpriteStore;
-
 /**
  * Test Suite for the Sprite Store class.
  * 

--- a/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.sprite.Sprite;
 
 /**
  * Test Suite for the Sprite class.


### PR DESCRIPTION
Distributing the classes over different packages has resulted in a lot of
redundant import rules, as reported by PMD and CheckStyle. These errors
have been fixed.

Also fixed remaining PMD errors.

<testing,organisation