### PR TITLE
Rebinded keys for SinglePlayer and Multiplayer

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/Constants.java
+++ b/src/main/java/nl/tudelft/scrumbledore/Constants.java
@@ -169,14 +169,26 @@ public final class Constants {
   private static List<Map<KeyCode, PlayerAction>> createKeyMapping() {
     List<Map<KeyCode, PlayerAction>> keyMapping = new ArrayList<Map<KeyCode, PlayerAction>>();
 
+    keyMapping.add(createKeyMappingMP1());
+    keyMapping.add(createKeyMappingMP2());
     keyMapping.add(createKeyMappingP1());
-    keyMapping.add(createKeyMappingP2());
 
     return keyMapping;
   }
 
-  // Performing key mapping for player one.
+  // Performing key mapping for player one in the single-player.
   private static Map<KeyCode, PlayerAction> createKeyMappingP1() {
+    Map<KeyCode, PlayerAction> keyMapping = new HashMap<KeyCode, PlayerAction>();
+    keyMapping.put(KeyCode.LEFT, PlayerAction.MoveLeft);
+    keyMapping.put(KeyCode.RIGHT, PlayerAction.MoveRight);
+    keyMapping.put(KeyCode.UP, PlayerAction.Jump);
+    keyMapping.put(KeyCode.E, PlayerAction.Shoot);
+
+    return keyMapping;
+  }
+
+  // Performing key mapping for player one in the multi-player.
+  private static Map<KeyCode, PlayerAction> createKeyMappingMP1() {
     Map<KeyCode, PlayerAction> keyMapping = new HashMap<KeyCode, PlayerAction>();
     keyMapping.put(KeyCode.LEFT, PlayerAction.MoveLeft);
     keyMapping.put(KeyCode.RIGHT, PlayerAction.MoveRight);
@@ -186,13 +198,13 @@ public final class Constants {
     return keyMapping;
   }
 
-  // Performing key mapping for player two.
-  private static Map<KeyCode, PlayerAction> createKeyMappingP2() {
+  // Performing key mapping for player two in the multi-player.
+  private static Map<KeyCode, PlayerAction> createKeyMappingMP2() {
     Map<KeyCode, PlayerAction> keyMapping = new HashMap<KeyCode, PlayerAction>();
     keyMapping.put(KeyCode.A, PlayerAction.MoveLeft);
     keyMapping.put(KeyCode.D, PlayerAction.MoveRight);
     keyMapping.put(KeyCode.W, PlayerAction.Jump);
-    keyMapping.put(KeyCode.Q, PlayerAction.Shoot);
+    keyMapping.put(KeyCode.V, PlayerAction.Shoot);
 
     return keyMapping;
   }

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/EventListeners.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/EventListeners.java
@@ -11,6 +11,7 @@ import javafx.stage.WindowEvent;
 import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.Logger;
 import nl.tudelft.scrumbledore.game.Game;
+import nl.tudelft.scrumbledore.game.SinglePlayerGame;
 import nl.tudelft.scrumbledore.level.Player;
 import nl.tudelft.scrumbledore.level.PlayerAction;
 
@@ -19,6 +20,7 @@ import nl.tudelft.scrumbledore.level.PlayerAction;
  * 
  * @author David Alderliesten
  * @author Jeroen Meijer
+ * @author Floris Doolaard
  */
 public class EventListeners {
   private Game game;
@@ -64,27 +66,39 @@ public class EventListeners {
    * Adds key press listeners.
    */
   private void keyPressListeners() {
+
     scene.setOnKeyPressed(new EventHandler<KeyEvent>() {
 
       public void handle(KeyEvent keyPressed) {
-        KeyCode keyCode = keyPressed.getCode();
         ArrayList<Player> players = game.getCurrentLevel().getPlayers();
-        Boolean playersLeft = false;
-        for (int i = 0; i < players.size(); i++) {
-          players.get(i).addAction(Constants.KEY_MAPPING.get(i).get(keyCode));
+        if (players.size() != 0) {
+          KeyCode keyCode = keyPressed.getCode();
+          Boolean playersLeft = false;
 
-          if (players.get(i).isAlive()) {
-            playersLeft = true;
+          if (game instanceof SinglePlayerGame) {
+            players.get(0).addAction(Constants.KEY_MAPPING.get(2).get(keyCode));
+            if (players.get(0).isAlive()) {
+              playersLeft = true;
+            }
+          } else {
+            for (int i = 0; i < players.size(); i++) {
+              players.get(i).addAction(Constants.KEY_MAPPING.get(i).get(keyCode));
+
+              if (players.get(i).isAlive()) {
+                playersLeft = true;
+              }
+            }
           }
-        }
 
-        // Restarting the game if "R" is pressed or when the player is dead.
-        if (keyCode == KeyCode.R || !playersLeft) {
-          game.restart();
-          // renderStatic();
+          // Restarting the game if "R" is pressed or when the player is dead.
+          if (keyCode == KeyCode.R || !playersLeft) {
+            game.restart();
+            // renderStatic();
+          }
         }
       }
     });
+
   }
 
   /**
@@ -96,9 +110,17 @@ public class EventListeners {
       public void handle(KeyEvent keyReleased) {
         KeyCode keyCode = keyReleased.getCode();
         ArrayList<Player> players = game.getCurrentLevel().getPlayers();
-        for (int i = 0; i < players.size(); i++) {
-          players.get(i)
-              .addAction(PlayerAction.invertAction(Constants.KEY_MAPPING.get(i).get(keyCode)));
+
+        if (players.size() != 0) {
+          if (game instanceof SinglePlayerGame) {
+            players.get(0).addAction(
+                PlayerAction.invertAction(Constants.KEY_MAPPING.get(2).get(keyCode)));
+          } else {
+            for (int i = 0; i < players.size(); i++) {
+              players.get(i).addAction(
+                  PlayerAction.invertAction(Constants.KEY_MAPPING.get(i).get(keyCode)));
+            }
+          }
         }
       }
     });
@@ -122,5 +144,5 @@ public class EventListeners {
       }
     });
   }
-  
+
 }


### PR DESCRIPTION
I have added another List to the KeyMapping with actions for SinglePlayer.
In the Singleplayer it is easier to have the action key and movement keys seperated over the range of the keyboard to easily game with two hands (E and arrow keys).
In the Multiplayer you will have different keybindings where hands will be close to each other (P1: Ctrl and arrow keys, P2: V and WAD keys).