### PR TITLE
Fix highscore

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/game/Game.java
+++ b/src/main/java/nl/tudelft/scrumbledore/game/Game.java
@@ -13,7 +13,6 @@ import nl.tudelft.scrumbledore.level.LevelModifier;
  * @author David Alderliesten
  */
 public abstract class Game {
-
   private ArrayList<Level> levels;
   private ArrayList<LevelModifier> modifiers;
   private Level currentLevel;
@@ -217,6 +216,7 @@ public abstract class Game {
    */
   public void restart() {
     levels = makeLevels();
+    score.resetScore();
     currentLevel = levels.get(0);
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/game/ScoreCounter.java
+++ b/src/main/java/nl/tudelft/scrumbledore/game/ScoreCounter.java
@@ -4,7 +4,7 @@ import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.Logger;
 
 /**
- * A counter given to the Game class as an attribute.
+ * A counter given to the Game class as an attribute that keeps track of the score.
  * 
  * @author Floris Doolaard
  * @author David Alderliesten
@@ -15,7 +15,6 @@ public class ScoreCounter {
 
   /**
    * Contructing a a ScoreCounter object.
-   *
    */
   public ScoreCounter() {
     this.score = 0;
@@ -59,17 +58,24 @@ public class ScoreCounter {
     score += addScore;
 
     if (Constants.isLoggingWantPoints()) {
-      Logger.getInstance()
-          .log("Player gained " + addScore + " points, totalling at " + score + " points.");
+      Logger.getInstance().log(
+          "Player gained " + addScore + " points, totalling at " + score + " points.");
     }
 
     if (score > highScore) {
       highScore = score;
 
       if (Constants.isLoggingWantPoints()) {
-        Logger.getInstance()
-            .log("The high-score has been changed and is now worth " + highScore + " points!");
+        Logger.getInstance().log(
+            "The high-score has been changed and is now worth " + highScore + " points!");
       }
     }
+  }
+
+  /**
+   * Resets the score to a value of 0 when called.
+   */
+  public void resetScore() {
+    score = 0;
   }
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Vector.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Vector.java
@@ -9,7 +9,6 @@ package nl.tudelft.scrumbledore.level;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class Vector implements Cloneable {
-
   private double entryX;
   private double entryY;
 

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/SettingsMenu.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/SettingsMenu.java
@@ -70,8 +70,6 @@ public final class SettingsMenu {
    */
   private static void generateTitle() {
     Label titleLabel = new Label(Constants.SETTINGS_LABEL);
-
-    // Setting a unique CSS ID for correct themeing.
     titleLabel.setId("settingstitle");
 
     currentBox.getChildren().add(titleLabel);

--- a/src/test/java/nl/tudelft/scrumbledore/ScoreCounterTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/ScoreCounterTest.java
@@ -20,13 +20,13 @@ public class ScoreCounterTest {
   @Test
   public void testScoreCounter() {
     ScoreCounter sc = new ScoreCounter();
-    
+
     assertEquals(0, sc.getScore());
   }
 
   /**
-   * Test whether the high score of a game is set correctly
-   * if the current score is higher than the previous high score.
+   * Test whether the high score of a game is set correctly if the current score is higher than the
+   * previous high score.
    */
   @Test
   public void testGetHighScore() {
@@ -36,95 +36,77 @@ public class ScoreCounterTest {
     sc.updateScore(42);
     assertEquals(42, sc.getHighScore());
   }
-  
+
   /**
-   * Check whether the string returned by the getScoreString
-   * method has the expected format.
+   * Check whether the string returned by the getScoreString method has the expected format.
    */
   @Test
   public void testGetScoreString() {
     ScoreCounter sc = new ScoreCounter();
     assertEquals("0", sc.getScoreString());
-    
+
     sc.updateScore(42);
     assertEquals("42", sc.getScoreString());
   }
+
   /**
-   * Test whether the score stays the same if 0 is added. 
+   * Test whether the score stays the same if 0 is added.
    */
   @Test
   public void testUpdateScoreZero() {
     ScoreCounter sc = new ScoreCounter();
     sc.updateScore(0);
-    
+
     assertEquals(0, sc.getScore());
   }
-  
+
   /**
-   * Test whether the score is updated accordingly based on a given number of points. 
+   * Test whether the score is updated accordingly based on a given number of points.
    */
   @Test
   public void testUpdateScore() {
     ScoreCounter sc = new ScoreCounter();
     sc.updateScore(42);
-    
+
     assertEquals(42, sc.getScore());
   }
 
   /**
-   * Test whether the score is updated accordingly if it is incremented twice. 
+   * Test whether the score is updated accordingly if it is incremented twice.
    */
   @Test
   public void testUpdateScoreTwice() {
     ScoreCounter sc = new ScoreCounter();
-    
+
     sc.updateScore(1);
     assertEquals(1, sc.getScore());
-    
+
     sc.updateScore(1);
     assertEquals(2, sc.getScore());
   }
-  
+
   /**
    * Test whether the reset maintains a score of zero at zero.
    */
   @Test
   public void testResetOnZero() {
     ScoreCounter sc = new ScoreCounter();
-    
+
     sc.resetScore();
     assertEquals(0, sc.getScore());
   }
-  
+
   /**
    * Test whether the score reset works after one incrementation.
    */
   @Test
   public void testResetOnce() {
     ScoreCounter sc = new ScoreCounter();
-    
+
     sc.updateScore(1);
-    assertEquals(1, sc.getScore());
-    
+
     sc.resetScore();
     assertEquals(0, sc.getScore());
   }
-  
-  /**
-   * Test whether the score reset works after two incrementations.
-   */
-  @Test
-  public void testResetTwice() {
-    ScoreCounter sc = new ScoreCounter();
-    
-    sc.updateScore(1);
-    assertEquals(1, sc.getScore());
-    
-    sc.updateScore(1);
-    assertEquals(2, sc.getScore());
-    
-    sc.resetScore();
-    assertEquals(0, sc.getScore());
-  }
-  
+
 }

--- a/src/test/java/nl/tudelft/scrumbledore/ScoreCounterTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/ScoreCounterTest.java
@@ -9,6 +9,7 @@ import nl.tudelft.scrumbledore.game.ScoreCounter;
 /**
  * Test suite for the scoreCounter class.
  * 
+ * @author David Alderliesten
  * @author Niels Warnars
  */
 public class ScoreCounterTest {
@@ -83,4 +84,47 @@ public class ScoreCounterTest {
     sc.updateScore(1);
     assertEquals(2, sc.getScore());
   }
+  
+  /**
+   * Test whether the reset maintains a score of zero at zero.
+   */
+  @Test
+  public void testResetOnZero() {
+    ScoreCounter sc = new ScoreCounter();
+    
+    sc.resetScore();
+    assertEquals(0, sc.getScore());
+  }
+  
+  /**
+   * Test whether the score reset works after one incrementation.
+   */
+  @Test
+  public void testResetOnce() {
+    ScoreCounter sc = new ScoreCounter();
+    
+    sc.updateScore(1);
+    assertEquals(1, sc.getScore());
+    
+    sc.resetScore();
+    assertEquals(0, sc.getScore());
+  }
+  
+  /**
+   * Test whether the score reset works after two incrementations.
+   */
+  @Test
+  public void testResetTwice() {
+    ScoreCounter sc = new ScoreCounter();
+    
+    sc.updateScore(1);
+    assertEquals(1, sc.getScore());
+    
+    sc.updateScore(1);
+    assertEquals(2, sc.getScore());
+    
+    sc.resetScore();
+    assertEquals(0, sc.getScore());
+  }
+  
 }


### PR DESCRIPTION
Implemented a reset for the score, so that the score is actually reset when the player dies.  Fixed the high score to keep active in the current session after death until the current score is higher than the tracked high score.

<bug, organization, testing