### PR TITLE
Level Elements uniformly rendered

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/level/Bubble.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Bubble.java
@@ -3,6 +3,8 @@ package nl.tudelft.scrumbledore.level;
 import java.util.ArrayList;
 
 import nl.tudelft.scrumbledore.Constants;
+import nl.tudelft.scrumbledore.sprite.Sprite;
+import nl.tudelft.scrumbledore.sprite.SpriteStore;
 
 /**
  * This class creates a Bubble object that the player can shoot.
@@ -79,28 +81,57 @@ public class Bubble extends LevelElement {
   public double getLifetime() {
     return lifetime;
   }
-  
+
   /**
    * Setting the life time of a bubble.
-   * @param newTime The new life time.
+   * 
+   * @param newTime
+   *          The new life time.
    */
   public void setLifetime(double newTime) {
     lifetime = newTime;
   }
-  
+
   /**
    * Return a boolean wether to see if a bubble has an NPC in it.
+   * 
    * @return Boolean of hasNPC.
    */
   public Boolean hasNPC() {
     return hasNPC;
   }
-  
+
   /**
    * Setting a boolean to hasNPC.
-   * @param bool The boolean that hasNPC has to be.
+   * 
+   * @param bool
+   *          The boolean that hasNPC has to be.
    */
   public void setHasNPC(Boolean bool) {
     hasNPC = bool;
+  }
+
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    SpriteStore store = SpriteStore.getInstance();
+    String id = "bubble-green-burst";
+    if (hasNPC()) {
+      id = "bubble-zenchan-green";
+      if (lifetime < 60 && lifetime % 15 < 8) {
+        id = "bubble-zenchan-red";
+      }
+    } else if (lifetime > 5 && lifetime < 40 && lifetime % 15 < 8) {
+      id = "bubble-red";
+    }
+    ArrayList<Sprite> result = new ArrayList<Sprite>();
+    result.add(store.getAnimated(id).getFrame(steps));
+    return result;
   }
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Bubble.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Bubble.java
@@ -121,7 +121,7 @@ public class Bubble extends LevelElement {
    */
   public ArrayList<Sprite> getSprites(double steps) {
     SpriteStore store = SpriteStore.getInstance();
-    String id = "bubble-green-burst";
+    String id = "bubble-green";
     if (hasNPC()) {
       id = "bubble-zenchan-green";
       if (lifetime < 60 && lifetime % 15 < 8) {
@@ -129,6 +129,8 @@ public class Bubble extends LevelElement {
       }
     } else if (lifetime > 5 && lifetime < 40 && lifetime % 15 < 8) {
       id = "bubble-red";
+    } else if (lifetime <= 5) {
+      id = "bubble-green-burst";
     }
     ArrayList<Sprite> result = new ArrayList<Sprite>();
     result.add(store.getAnimated(id).getFrame(steps));

--- a/src/main/java/nl/tudelft/scrumbledore/level/Fruit.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Fruit.java
@@ -1,5 +1,10 @@
 package nl.tudelft.scrumbledore.level;
 
+import java.util.ArrayList;
+
+import nl.tudelft.scrumbledore.sprite.Sprite;
+import nl.tudelft.scrumbledore.sprite.SpriteStore;
+
 /**
  * Class representing a Fruit in a game.
  * 
@@ -33,8 +38,7 @@ public class Fruit extends LevelElement {
   public boolean equals(Object other) {
     if (other instanceof Fruit) {
       Fruit that = (Fruit) other;
-      return this.getPosition().equals(that.getPosition())
-          && this.getSize().equals(that.getSize());
+      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
     }
 
     return false;
@@ -76,6 +80,22 @@ public class Fruit extends LevelElement {
    */
   public void setPickable(Boolean bool) {
     pickable = bool;
+  }
+
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    SpriteStore store = SpriteStore.getInstance();
+    String id = "fruit";
+    ArrayList<Sprite> result = new ArrayList<Sprite>();
+    result.add(store.getAnimated(id).getFrame(posX()));
+    return result;
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Fruit.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Fruit.java
@@ -92,9 +92,8 @@ public class Fruit extends LevelElement {
    */
   public ArrayList<Sprite> getSprites(double steps) {
     SpriteStore store = SpriteStore.getInstance();
-    String id = "fruit";
     ArrayList<Sprite> result = new ArrayList<Sprite>();
-    result.add(store.getAnimated(id).getFrame(posX()));
+    result.add(store.getAnimated("fruit").getFrame(posX()));
     return result;
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/level/Level.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Level.java
@@ -50,6 +50,31 @@ public class Level {
   }
 
   /**
+   * Get all the dynamic elements in the Level (elements that are updated every cycle).
+   * 
+   * @return All Dynamic Level Elements.
+   */
+  public ArrayList<LevelElement> getDynamicElements() {
+    ArrayList<LevelElement> elements = new ArrayList<LevelElement>();
+    elements.addAll(players);
+    elements.addAll(npcs);
+    elements.addAll(fruits);
+    elements.addAll(bubbles);
+    return elements;
+  }
+
+  /**
+   * Get all the static elements in the Level (elements that are not updated every cycle).
+   * 
+   * @return All Static Level Elements.
+   */
+  public ArrayList<LevelElement> getStaticElements() {
+    ArrayList<LevelElement> elements = new ArrayList<LevelElement>();
+    elements.addAll(platforms);
+    return elements;
+  }
+
+  /**
    * Returns an ArrayList of Platform elements.
    * 
    * @return An ArrayList of Platform elements

--- a/src/main/java/nl/tudelft/scrumbledore/level/LevelElement.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/LevelElement.java
@@ -1,5 +1,9 @@
 package nl.tudelft.scrumbledore.level;
 
+import java.util.ArrayList;
+
+import nl.tudelft.scrumbledore.sprite.Sprite;
+
 /**
  * Abstract class representing an element that can be placed in a Level.
  * 
@@ -235,5 +239,15 @@ public abstract class LevelElement {
     boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
     return inX && inY;
   }
+
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public abstract ArrayList<Sprite> getSprites(double steps);
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/NPC.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/NPC.java
@@ -2,6 +2,9 @@ package nl.tudelft.scrumbledore.level;
 
 import java.util.ArrayList;
 
+import nl.tudelft.scrumbledore.sprite.Sprite;
+import nl.tudelft.scrumbledore.sprite.SpriteStore;
+
 /**
  * Class representing an NPC in a game.
  * 
@@ -104,6 +107,25 @@ public class NPC extends LevelElement {
     if (action == NPCAction.MoveLeft || action == NPCAction.MoveRight) {
       lastMove = action;
     }
+  }
+  
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    SpriteStore store = SpriteStore.getInstance();
+    String id = "zenchan-move-right";
+    if (getLastMove().equals(NPCAction.MoveLeft)) {
+      id = "zenchan-move-left";
+    }
+    ArrayList<Sprite> result = new ArrayList<Sprite>();
+    result.add(store.getAnimated(id).getFrame(steps));
+    return result;
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Platform.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Platform.java
@@ -1,5 +1,10 @@
 package nl.tudelft.scrumbledore.level;
 
+import java.util.ArrayList;
+
+import nl.tudelft.scrumbledore.sprite.Sprite;
+import nl.tudelft.scrumbledore.sprite.SpriteStore;
+
 /**
  * Class representing a Platform in a game.
  * 
@@ -60,6 +65,22 @@ public class Platform extends LevelElement {
    */
   public void setPassable(boolean isPassable) {
     this.isPassable = isPassable;
+  }
+  
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    SpriteStore store = SpriteStore.getInstance();
+    String id = "wall-1";
+    ArrayList<Sprite> result = new ArrayList<Sprite>();
+    result.add(store.get(id));
+    return result;
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Player.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Player.java
@@ -2,6 +2,10 @@ package nl.tudelft.scrumbledore.level;
 
 import java.util.ArrayList;
 
+import nl.tudelft.scrumbledore.Constants;
+import nl.tudelft.scrumbledore.sprite.Sprite;
+import nl.tudelft.scrumbledore.sprite.SpriteStore;
+
 /**
  * Class representing a Player in a game.
  * 
@@ -88,12 +92,12 @@ public class Player extends LevelElement {
    * Sets the id of the current player.
    * 
    * @param id
-   *         Integer that represents the players number in the game.
+   *          Integer that represents the players number in the game.
    */
   public void setPlayerNumber(int id) {
     this.id = id;
   }
-  
+
   /**
    * Check whether the given action is queued for the next step.
    * 
@@ -145,8 +149,7 @@ public class Player extends LevelElement {
   public boolean equals(Object other) {
     if (other instanceof Player) {
       Player that = (Player) other;
-      return this.getPosition().equals(that.getPosition())
-          && this.getSize().equals(that.getSize());
+      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
     }
 
     return false;
@@ -169,6 +172,36 @@ public class Player extends LevelElement {
    */
   public void setFiring(Boolean isFiring) {
     this.firing = isFiring;
+  }
+
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    SpriteStore store = SpriteStore.getInstance();
+    boolean toRight = getLastMove() == PlayerAction.MoveRight;
+    
+    String id = "move-left";
+    if (firing && toRight) {
+      id = "shoot-right";
+    } else if (firing) {
+      id = "shoot-left";
+    } else if (toRight) {
+      id = "move-right";
+    }
+    if (getSpeed().getX() == 0 && !firing) {
+      steps = 0;
+    }
+    
+    id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
+    ArrayList<Sprite> result = new ArrayList<Sprite>();
+    result.add(store.getAnimated(id).getFrame(steps));
+    return result;
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Player.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Player.java
@@ -183,24 +183,27 @@ public class Player extends LevelElement {
    * @return Sprites to be drawn.
    */
   public ArrayList<Sprite> getSprites(double steps) {
-    SpriteStore store = SpriteStore.getInstance();
-    boolean toRight = getLastMove() == PlayerAction.MoveRight;
-    
-    String id = "move-left";
-    if (firing && toRight) {
-      id = "shoot-right";
-    } else if (firing) {
-      id = "shoot-left";
-    } else if (toRight) {
-      id = "move-right";
-    }
-    if (getSpeed().getX() == 0 && !firing) {
-      steps = 0;
-    }
-    
-    id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
     ArrayList<Sprite> result = new ArrayList<Sprite>();
-    result.add(store.getAnimated(id).getFrame(steps));
+    SpriteStore store = SpriteStore.getInstance();
+    if (alive) {
+      boolean toRight = getLastMove() == PlayerAction.MoveRight;
+
+      String id = "move-left";
+      if (firing && toRight) {
+        id = "shoot-right";
+      } else if (firing) {
+        id = "shoot-left";
+      } else if (toRight) {
+        id = "move-right";
+      }
+      if (getSpeed().getX() == 0 && !firing) {
+        steps = 0;
+      }
+
+      id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
+
+      result.add(store.getAnimated(id).getFrame(steps));
+    }
     return result;
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
+++ b/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 
 import nl.tudelft.scrumbledore.Constants;
-import nl.tudelft.scrumbledore.Logger;
 
 /**
  * The Sprite Store reads and creates Sprites from the file system and allows to easily select and
@@ -19,7 +18,7 @@ public class SpriteStore {
   private ArrayList<AnimatedSprite> animatedSprites;
   private String dir;
   private String dirSprite;
-  
+
   private static volatile SpriteStore instance;
 
   /**
@@ -30,7 +29,7 @@ public class SpriteStore {
     this.dirSprite = Constants.SPRITES_DIR;
     read();
   }
-  
+
   /**
    * Creates a new SpriteStore instance if it has not yet been instantiated.
    * 

--- a/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
+++ b/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 
 import nl.tudelft.scrumbledore.Constants;
+import nl.tudelft.scrumbledore.Logger;
 
 /**
  * The Sprite Store reads and creates Sprites from the file system and allows to easily select and
@@ -18,14 +19,32 @@ public class SpriteStore {
   private ArrayList<AnimatedSprite> animatedSprites;
   private String dir;
   private String dirSprite;
+  
+  private static volatile SpriteStore instance;
 
   /**
    * Construct a new Sprite Store by reading the Sprites from the file system.
    */
-  public SpriteStore() {
+  private SpriteStore() {
     this.dir = Constants.RESOURCES_DIR + Constants.SPRITES_DIR;
     this.dirSprite = Constants.SPRITES_DIR;
     read();
+  }
+  
+  /**
+   * Creates a new SpriteStore instance if it has not yet been instantiated.
+   * 
+   * @return The single SpriteStore instance.
+   */
+  public static SpriteStore getInstance() {
+    if (instance == null) {
+      synchronized (SpriteStore.class) {
+        if (instance == null) {
+          instance = new SpriteStore();
+        }
+      }
+    }
+    return instance;
   }
 
   /**

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
@@ -53,7 +53,6 @@ public final class GameDisplay {
   private static Canvas dynamicCanvas;
   private static GraphicsContext staticContext;
   private static GraphicsContext dynamicContext;
-  private static SpriteStore sprites;
   private static Label scoreLabel;
   private static Label highScoreLabel;
   private static Label levelLabel;
@@ -118,7 +117,7 @@ public final class GameDisplay {
 
     renderStatic();
     animationTimer.start();
-    
+
     currentScene = new Scene(currentLayout);
     currentScene.getStylesheets().add(Constants.CSS_GAMEVIEW);
     currentStage.setScene(currentScene);
@@ -133,8 +132,6 @@ public final class GameDisplay {
    * Prepares the game by launching the sprite storage, game instance, and timer instance.
    */
   private static void prepareGame() {
-    sprites = new SpriteStore();
-
     currentTimer = new StepTimer(Constants.REFRESH_RATE, currentGame);
     currentTimer.start();
   }
@@ -279,20 +276,20 @@ public final class GameDisplay {
             (Constants.LEVELY / 2) - 130);
         endStepsSnapShot = currentGame.getSteps();
       }
-      
+
       if (endStepsSnapShot + Constants.REFRESH_RATE * 4 < currentGame.getSteps()) {
         if (currentGame.remainingLevels() == 0) {
           Logger.getInstance().log("Player completed the game successfully.");
-  
+
           animationTimer.stop();
-  
+
           winDialog();
         } else {
           Logger.getInstance().log("Player advanced to the next level.");
           currentGame.goToNextLevel();
           GameDisplay.renderStatic();
         }
-        
+
         endStepsSnapShot = 0;
       }
     }
@@ -344,7 +341,8 @@ public final class GameDisplay {
     staticContext.clearRect(0, 0, Constants.GUIX, Constants.GUIY);
 
     for (Platform current : currentGame.getCurrentLevel().getPlatforms()) {
-      staticContext.drawImage(new Image(sprites.get("wall-1").getPath()),
+      dynamicContext.drawImage(
+          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
           current.getPosition().getX(), current.getPosition().getY());
     }
   }
@@ -372,25 +370,9 @@ public final class GameDisplay {
     ArrayList<Player> players = currentGame.getCurrentLevel().getPlayers();
     for (Player player : players) {
       if (player.isAlive()) {
-        double steps = currentGame.getSteps();
-        boolean toRight = player.getLastMove() == PlayerAction.MoveRight;
-        boolean isFiring = player.isFiring();
-        String spr = "move-left";
-        if (isFiring && toRight) {
-          spr = "shoot-right";
-        } else if (isFiring) {
-          spr = "shoot-left";
-        } else if (toRight) {
-          spr = "move-right";
-        }
-        if (player.getSpeed().getX() == 0 && !isFiring) {
-          steps = 0;
-        }
-        String path = 
-            sprites.getAnimated("player-" + Constants.PLAYER_COLORS.get(player.getPlayerNumber()) 
-              + "-" + spr).getFrame(steps).getPath();
-        dynamicContext.drawImage(new Image(path), player.getPosition().getX(),
-            player.getPosition().getY());
+        dynamicContext.drawImage(
+            new Image(player.getSprites(currentGame.getSteps()).get(0).getPath()),
+            player.getPosition().getX(), player.getPosition().getY());
       }
     }
   }
@@ -405,24 +387,9 @@ public final class GameDisplay {
     }
 
     for (Bubble currentBubble : bubbles) {
-      String path = sprites.getAnimated("bubble-green").getFrame(currentGame.getSteps()).getPath();
-      double bubbleLifetime = currentBubble.getLifetime();
-
-      if (currentBubble.hasNPC()) {
-        if (bubbleLifetime < 60 && bubbleLifetime % 15 < 8) {
-          path = sprites.getAnimated("bubble-zenchan-red").getFrame(currentGame.getSteps())
-              .getPath();
-        } else {
-          path = sprites.getAnimated("bubble-zenchan-green").getFrame(currentGame.getSteps())
-            .getPath();
-        }
-      } else if (bubbleLifetime > 5 && bubbleLifetime < 40 && bubbleLifetime % 15 < 8) {
-        path = sprites.getAnimated("bubble-red").getFrame(currentGame.getSteps()).getPath();
-      } else if (bubbleLifetime <= 5) {
-        path = sprites.getAnimated("bubble-green-burst").getFrame(currentGame.getSteps()).getPath();
-      }
-      dynamicContext.drawImage(new Image(path), currentBubble.getPosition().getX(),
-          currentBubble.getPosition().getY());
+      dynamicContext.drawImage(
+          new Image(currentBubble.getSprites(currentGame.getSteps()).get(0).getPath()),
+          currentBubble.getPosition().getX(), currentBubble.getPosition().getY());
     }
   }
 
@@ -438,13 +405,9 @@ public final class GameDisplay {
     }
 
     for (NPC current : npcs) {
-      String spr = "zenchan-move-right";
-      if (current.getLastMove().equals(NPCAction.MoveLeft)) {
-        spr = "zenchan-move-left";
-      }
-      String path = sprites.getAnimated(spr).getFrame(steps).getPath();
-      dynamicContext.drawImage(new Image(path), current.getPosition().getX(),
-          current.getPosition().getY());
+      dynamicContext.drawImage(
+          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
+          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 
@@ -456,9 +419,9 @@ public final class GameDisplay {
     }
 
     for (Fruit current : fruits) {
-      String path = sprites.getAnimated("fruit").getFrame(current.posX()).getPath();
-      dynamicContext.drawImage(new Image(path), current.getPosition().getX(),
-          current.getPosition().getY());
+      dynamicContext.drawImage(
+          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
+          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
@@ -1,6 +1,7 @@
 package nl.tudelft.scrumbledore.userinterface;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import javafx.animation.AnimationTimer;
 import javafx.event.ActionEvent;
@@ -23,15 +24,10 @@ import nl.tudelft.scrumbledore.Logger;
 import nl.tudelft.scrumbledore.StepTimer;
 import nl.tudelft.scrumbledore.game.Game;
 import nl.tudelft.scrumbledore.game.GameFactory;
-import nl.tudelft.scrumbledore.level.Bubble;
-import nl.tudelft.scrumbledore.level.Fruit;
 import nl.tudelft.scrumbledore.level.Level;
-import nl.tudelft.scrumbledore.level.NPC;
-import nl.tudelft.scrumbledore.level.NPCAction;
-import nl.tudelft.scrumbledore.level.Platform;
+import nl.tudelft.scrumbledore.level.LevelElement;
 import nl.tudelft.scrumbledore.level.Player;
-import nl.tudelft.scrumbledore.level.PlayerAction;
-import nl.tudelft.scrumbledore.sprite.SpriteStore;
+import nl.tudelft.scrumbledore.sprite.Sprite;
 
 /**
  * Class responsible for displaying, running, updating, and interacting with the game for one or two
@@ -340,11 +336,8 @@ public final class GameDisplay {
   private static void renderStatic() {
     staticContext.clearRect(0, 0, Constants.GUIX, Constants.GUIY);
 
-    for (Platform current : currentGame.getCurrentLevel().getPlatforms()) {
-      dynamicContext.drawImage(
-          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
-          current.getPosition().getX(), current.getPosition().getY());
-    }
+    ArrayList<LevelElement> staticElements = currentGame.getCurrentLevel().getStaticElements();
+    renderLevelElements(staticElements, staticContext);
   }
 
   /**
@@ -353,10 +346,8 @@ public final class GameDisplay {
   private static void renderDynamic() {
     dynamicContext.clearRect(0, 0, Constants.GUIX, Constants.GUIY);
 
-    renderPlayer();
-    renderBubbles();
-    renderNPC();
-    renderFruit();
+    ArrayList<LevelElement> dynamicElements = currentGame.getCurrentLevel().getDynamicElements();
+    renderLevelElements(dynamicElements, dynamicContext);
 
     scoreLabel.setText(currentGame.getScore());
     highScoreLabel.setText(currentGame.getHighScore());
@@ -364,64 +355,20 @@ public final class GameDisplay {
   }
 
   /**
-   * Renders the player(s) on the map.
+   * Render a given list of level elements to a given context of the Game Display.
+   * 
+   * @param elements
+   *          The Level Elements to be rendered.
+   * @param context
+   *          The Graphics Context in which the elements should be drawn.
    */
-  private static void renderPlayer() {
-    ArrayList<Player> players = currentGame.getCurrentLevel().getPlayers();
-    for (Player player : players) {
-      if (player.isAlive()) {
-        dynamicContext.drawImage(
-            new Image(player.getSprites(currentGame.getSteps()).get(0).getPath()),
-            player.getPosition().getX(), player.getPosition().getY());
+  private static void renderLevelElements(List<LevelElement> elements, GraphicsContext context) {
+    for (LevelElement element : elements) {
+      for (Sprite sprite : element.getSprites(currentGame.getSteps())) {
+        context.drawImage(new Image(sprite.getPath()), element.getPosition().getX(),
+            element.getPosition().getY());
       }
-    }
-  }
 
-  /**
-   * Renders the bubble projectile(s) on the map.
-   */
-  private static void renderBubbles() {
-    ArrayList<Bubble> bubbles = new ArrayList<Bubble>();
-    for (Bubble bubble : currentGame.getCurrentLevel().getBubbles()) {
-      bubbles.add(bubble);
-    }
-
-    for (Bubble currentBubble : bubbles) {
-      dynamicContext.drawImage(
-          new Image(currentBubble.getSprites(currentGame.getSteps()).get(0).getPath()),
-          currentBubble.getPosition().getX(), currentBubble.getPosition().getY());
-    }
-  }
-
-  /**
-   * Renders the non-player characters on the map.
-   */
-  private static void renderNPC() {
-    ArrayList<NPC> npcs = new ArrayList<NPC>();
-    double steps = currentGame.getSteps();
-
-    for (NPC npc : currentGame.getCurrentLevel().getNPCs()) {
-      npcs.add(npc);
-    }
-
-    for (NPC current : npcs) {
-      dynamicContext.drawImage(
-          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
-          current.getPosition().getX(), current.getPosition().getY());
-    }
-  }
-
-  private static void renderFruit() {
-    ArrayList<Fruit> fruits = new ArrayList<Fruit>();
-
-    for (Fruit fruit : currentGame.getCurrentLevel().getFruits()) {
-      fruits.add(fruit);
-    }
-
-    for (Fruit current : fruits) {
-      dynamicContext.drawImage(
-          new Image(current.getSprites(currentGame.getSteps()).get(0).getPath()),
-          current.getPosition().getX(), current.getPosition().getY());
     }
   }
 

--- a/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteStoreTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/sprite/SpriteStoreTest.java
@@ -27,7 +27,7 @@ public class SpriteStoreTest {
     assertTrue(test.getAll().get(0).getID().equals("test"));
 
     // Additionally test constructor with zero parameters, just for the line coverage.
-    SpriteStore additionalTest = new SpriteStore();
+    SpriteStore additionalTest = SpriteStore.getInstance();
     assertFalse(additionalTest.getAll().isEmpty());
   }
 


### PR DESCRIPTION
Level Elements now all have their own method for getting the sprites that
are to be drawn at the element's position. The GameDisplay can now
treat all Level Elements uniformly, conforming better to the Liskov
substitution principle. There is still the distinction between drawing static and
dynamic elements, but these mechanisms use a shared method for rendering
Level Elements.

Issue: #226.
<organisation
