### PR TITLE
Update Sprites to be drawn from center.

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/sprite/Sprite.java
+++ b/src/main/java/nl/tudelft/scrumbledore/sprite/Sprite.java
@@ -1,6 +1,7 @@
 package nl.tudelft.scrumbledore.sprite;
 
 import nl.tudelft.scrumbledore.Constants;
+import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * Represents a sprite that can be drawn in the GUI as a visual representation of a LevelElement.
@@ -13,6 +14,7 @@ public class Sprite {
   private String id;
   private String ext;
   private String dir;
+  private Vector size;
 
   /**
    * Constructs a new sprite instance with the given id to reference an image file.
@@ -59,6 +61,26 @@ public class Sprite {
   }
 
   /**
+   * Constructs a new sprite instance with the given id to reference an image file, the extension of
+   * the file, the directory to look for it and its size.
+   * 
+   * @param id
+   *          Reference to an image file.
+   * @param ext
+   *          The extension of the image file.
+   * @param dir
+   *          The directory to look for the file.
+   * @param size
+   *          A Vector describing the dimensions of the image.
+   */
+  public Sprite(String id, String ext, String dir, Vector size) {
+    this.id = id;
+    this.ext = ext;
+    this.dir = dir;
+    this.size = size;
+  }
+
+  /**
    * Get the ID of this Sprite.
    * 
    * @return The ID.
@@ -75,5 +97,17 @@ public class Sprite {
   public String getPath() {
     return dir + id + "." + ext;
   }
-  
+
+  /**
+   * Get the drawing position of the image given the absolute position where it's origin point
+   * should be.
+   * 
+   * @param origin
+   *          The absolute position for the origin of the sprite.
+   * @return A Vector describing the drawing position.
+   */
+  public Vector getDrawPosition(Vector origin) {
+    return Vector.sum(origin, Vector.scale(size, -.5));
+  }
+
 }

--- a/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
+++ b/src/main/java/nl/tudelft/scrumbledore/sprite/SpriteStore.java
@@ -1,9 +1,14 @@
 package nl.tudelft.scrumbledore.sprite;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
+import javax.imageio.ImageIO;
+
 import nl.tudelft.scrumbledore.Constants;
+import nl.tudelft.scrumbledore.level.Vector;
 
 /**
  * The Sprite Store reads and creates Sprites from the file system and allows to easily select and
@@ -126,7 +131,17 @@ public class SpriteStore {
     int pos = name.lastIndexOf('.');
     String id = name.substring(0, pos);
     String ext = name.substring(pos + 1);
-    return new Sprite(id, ext, dir);
+
+    Vector size = new Vector(0, 0);
+    try {
+      BufferedImage sprite = ImageIO.read(file);
+      size.setX(sprite.getWidth());
+      size.setY(sprite.getHeight());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return new Sprite(id, ext, dir, size);
   }
 
   /**

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
@@ -27,6 +27,7 @@ import nl.tudelft.scrumbledore.game.GameFactory;
 import nl.tudelft.scrumbledore.level.Level;
 import nl.tudelft.scrumbledore.level.LevelElement;
 import nl.tudelft.scrumbledore.level.Player;
+import nl.tudelft.scrumbledore.level.Vector;
 import nl.tudelft.scrumbledore.sprite.Sprite;
 
 /**
@@ -336,8 +337,7 @@ public final class GameDisplay {
   private static void renderStatic() {
     staticContext.clearRect(0, 0, Constants.GUIX, Constants.GUIY);
 
-    ArrayList<LevelElement> staticElements = currentGame.getCurrentLevel().getStaticElements();
-    renderLevelElements(staticElements, staticContext);
+    renderLevelElements(currentGame.getCurrentLevel().getStaticElements(), staticContext);
   }
 
   /**
@@ -346,8 +346,7 @@ public final class GameDisplay {
   private static void renderDynamic() {
     dynamicContext.clearRect(0, 0, Constants.GUIX, Constants.GUIY);
 
-    ArrayList<LevelElement> dynamicElements = currentGame.getCurrentLevel().getDynamicElements();
-    renderLevelElements(dynamicElements, dynamicContext);
+    renderLevelElements(currentGame.getCurrentLevel().getDynamicElements(), dynamicContext);
 
     scoreLabel.setText(currentGame.getScore());
     highScoreLabel.setText(currentGame.getHighScore());
@@ -365,8 +364,10 @@ public final class GameDisplay {
   private static void renderLevelElements(List<LevelElement> elements, GraphicsContext context) {
     for (LevelElement element : elements) {
       for (Sprite sprite : element.getSprites(currentGame.getSteps())) {
-        context.drawImage(new Image(sprite.getPath()), element.getPosition().getX(),
-            element.getPosition().getY());
+        Vector drawPos = sprite.getDrawPosition(element.getPosition());
+        // Because all Sprites are drawn at their center they need an offset to be in the grid.
+        drawPos.sum(Vector.scale(new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE), .5));
+        context.drawImage(new Image(sprite.getPath()), drawPos.getX(), drawPos.getY());
       }
 
     }


### PR DESCRIPTION
Sprites are now drawn at their center point instead of their top left
corner. The SpriteStore now reads and the Sprite stores the dimensions of
the Sprite image.

Issue #226

<feature,organisation
