### PR TITLE
Fix spacebar press

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/keybinding/KeybindingContainer.java
+++ b/src/main/java/nl/tudelft/scrumbledore/keybinding/KeybindingContainer.java
@@ -10,11 +10,11 @@ import nl.tudelft.scrumbledore.level.PlayerAction;
 /**
  * A custom container for Keybindings. One Keybinding per player.
  * 
+ * @author David Alderliesten
  * @author Jeroen Meijer
  */
 public final class KeybindingContainer {
   private static KeybindingContainer keybindingContainer;
-
   private List<Keybinding> keybindingList;
 
   private KeybindingContainer() {

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
@@ -2,6 +2,7 @@ package nl.tudelft.scrumbledore.userinterface;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javafx.animation.AnimationTimer;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -13,6 +14,8 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -121,6 +124,8 @@ public final class GameDisplay {
 
     KeyListeners listeners = new KeyListeners(currentGame, currentScene);
     listeners.init();
+
+    removeSpacebarFunctionality();
 
     currentStage.show();
   }
@@ -378,4 +383,17 @@ public final class GameDisplay {
     }
   }
 
+  /**
+   * Removes the ability to use the spacebar to accidentally pause/play/trigger button events in the
+   * game.
+   */
+  private static void removeSpacebarFunctionality() {
+    currentScene.addEventHandler(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
+      public void handle(KeyEvent t) {
+        if (t.getCode() == KeyCode.SPACE) {
+          return;
+        }
+      }
+    });
+  }
 }

--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/KeybindingSettings.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/KeybindingSettings.java
@@ -30,7 +30,6 @@ import nl.tudelft.scrumbledore.level.PlayerAction;
  * @author Jeroen Meijer
  */
 public final class KeybindingSettings {
-
   private static VBox currentBox;
   private static VBox actionBinders;
   private static int selectedPlayer;


### PR DESCRIPTION
Fixed the spacebar pressing issue, in which pressing the spacebar could be pressed to perform random actions in the game.

The fix is sadly a bad one.  According to the JDoc/Community support given to this issue, it is impossible to make a good solution for this problem that does not cause cross-platform issues.

As of such, the fix is sadly only applicable to some devices.  The fix works on my desktop/primary laptop, but fails on my secondary laptop.

<bug, organization
