### PR TITLE
Increase Levelelement Intelligence with Stopping and Snapping

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/game/GameFactory.java
+++ b/src/main/java/nl/tudelft/scrumbledore/game/GameFactory.java
@@ -50,7 +50,7 @@ public class GameFactory {
     LevelModifier player = new PlayerActionsLevelModifier();
     LevelModifier gravity = new GravityLevelModifier();
     LevelModifier npc = new NPCLevelModifier();
-    LevelModifier collisions = new CollisionsLevelModifier(kinetics, game.getScoreCounter());
+    LevelModifier collisions = new CollisionsLevelModifier(game.getScoreCounter());
     LevelModifier bubbles = new BubbleActionsLevelModifier();
 
     game.registerLevelModifier(player);

--- a/src/main/java/nl/tudelft/scrumbledore/game/GameFactory.java
+++ b/src/main/java/nl/tudelft/scrumbledore/game/GameFactory.java
@@ -4,9 +4,9 @@ import nl.tudelft.scrumbledore.level.BubbleActionsLevelModifier;
 import nl.tudelft.scrumbledore.level.CollisionsLevelModifier;
 import nl.tudelft.scrumbledore.level.GravityLevelModifier;
 import nl.tudelft.scrumbledore.level.KineticsLevelModifier;
-import nl.tudelft.scrumbledore.level.LevelModifier;
 import nl.tudelft.scrumbledore.level.NPCLevelModifier;
 import nl.tudelft.scrumbledore.level.PlayerActionsLevelModifier;
+import nl.tudelft.scrumbledore.level.WarpLevelModifier;
 
 /**
  * Class responsible for creating different types of Games. Conforming to the Factory design
@@ -46,19 +46,13 @@ public class GameFactory {
   }
 
   private void makeLevelModifiers(Game game) {
-    KineticsLevelModifier kinetics = new KineticsLevelModifier();
-    LevelModifier player = new PlayerActionsLevelModifier();
-    LevelModifier gravity = new GravityLevelModifier();
-    LevelModifier npc = new NPCLevelModifier();
-    LevelModifier collisions = new CollisionsLevelModifier(game.getScoreCounter());
-    LevelModifier bubbles = new BubbleActionsLevelModifier();
-
-    game.registerLevelModifier(player);
-    game.registerLevelModifier(gravity);
-    game.registerLevelModifier(npc);
-    game.registerLevelModifier(bubbles);
-    game.registerLevelModifier(collisions);
-    game.registerLevelModifier(kinetics);
+    game.registerLevelModifier(new PlayerActionsLevelModifier());
+    game.registerLevelModifier(new GravityLevelModifier());
+    game.registerLevelModifier(new NPCLevelModifier());
+    game.registerLevelModifier(new BubbleActionsLevelModifier());
+    game.registerLevelModifier(new CollisionsLevelModifier(game.getScoreCounter()));
+    game.registerLevelModifier(new KineticsLevelModifier());
+    game.registerLevelModifier(new WarpLevelModifier());
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.Logger;
 import nl.tudelft.scrumbledore.game.ScoreCounter;
-import nl.tudelft.scrumbledore.powerup.Powerup;
 import nl.tudelft.scrumbledore.powerup.PowerupPickUp;
 
 /**
@@ -58,8 +57,10 @@ public class CollisionsLevelModifier implements LevelModifier {
   /**
    * Detect collisions between player and powerups.
    * 
-   * @param level , the level.
-   * @param delta , the delta provided by StepTimer.
+   * @param level
+   *          , the level.
+   * @param delta
+   *          , the delta provided by StepTimer.
    */
   protected void detectPlayerPowerup(Level level, double delta) {
     ArrayList<PowerupPickUp> powerUps = level.getPowerups();
@@ -108,8 +109,8 @@ public class CollisionsLevelModifier implements LevelModifier {
           Collision collision = new Collision(fruit, platform, delta);
 
           if (collision.collidingFromTop() && fruit.vSpeed() > 0) {
-            kinetics.stopVertically(fruit);
-            kinetics.snapTop(fruit, platform);
+            fruit.stopVertically();
+            fruit.snapTop(platform);
           }
         }
       }
@@ -134,8 +135,8 @@ public class CollisionsLevelModifier implements LevelModifier {
           Collision collision = new Collision(player, platform, delta);
 
           if (collision.collidingFromTop() && player.vSpeed() > 0) {
-            kinetics.stopVertically(player);
-            kinetics.snapTop(player, platform);
+            player.stopVertically();
+            player.snapTop(platform);
           }
         }
       }
@@ -145,18 +146,18 @@ public class CollisionsLevelModifier implements LevelModifier {
 
         if (!platform.isPassable()) {
           if (collision.collidingFromBottom() && player.vSpeed() < 0) {
-            kinetics.stopVertically(player);
-            kinetics.snapBottom(player, platform);
+            player.stopVertically();
+            player.snapBottom(platform);
           }
 
           if (collision.collidingFromLeft() && player.hSpeed() > 0) {
-            kinetics.stopHorizontally(player);
-            kinetics.snapLeft(player, platform);
+            player.stopHorizontally();
+            player.snapLeft(platform);
           }
 
           if (collision.collidingFromRight() && player.hSpeed() < 0) {
-            kinetics.stopHorizontally(player);
-            kinetics.snapRight(player, platform);
+            player.stopHorizontally();
+            player.snapRight(platform);
           }
         }
       }
@@ -181,8 +182,8 @@ public class CollisionsLevelModifier implements LevelModifier {
           Collision collision = new Collision(npc, platform, delta);
 
           if (collision.collidingFromTop() && npc.vSpeed() > 0) {
-            kinetics.stopVertically(npc);
-            kinetics.snapTop(npc, platform);
+            npc.stopVertically();
+            npc.snapTop(platform);
           }
         }
       }
@@ -192,14 +193,14 @@ public class CollisionsLevelModifier implements LevelModifier {
 
         if (!platform.isPassable()) {
           if (collision.collidingFromLeft() && npc.hSpeed() > 0) {
-            kinetics.stopHorizontally(npc);
-            kinetics.snapLeft(npc, platform);
+            npc.stopHorizontally();
+            npc.snapLeft(platform);
             npc.addAction(NPCAction.MoveLeft);
           }
 
           if (collision.collidingFromRight() && npc.hSpeed() < 0) {
-            kinetics.stopHorizontally(npc);
-            kinetics.snapRight(npc, platform);
+            npc.stopHorizontally();
+            npc.snapRight(platform);
             npc.addAction(NPCAction.MoveRight);
           }
         }
@@ -225,19 +226,19 @@ public class CollisionsLevelModifier implements LevelModifier {
 
           if (collision.collidingFromBottom()) {
             bubble.getSpeed().setY(Constants.BUBBLE_BOUNCE);
-            kinetics.snapBottom(bubble, platform);
+            bubble.snapBottom(platform);
             break;
           }
 
           if (collision.collidingFromLeft()) {
             bubble.getSpeed().setX(-Constants.BUBBLE_BOUNCE);
-            kinetics.snapLeft(bubble, platform);
+            bubble.snapLeft(platform);
             break;
           }
 
           if (collision.collidingFromRight()) {
             bubble.getSpeed().setX(Constants.BUBBLE_BOUNCE);
-            kinetics.snapRight(bubble, platform);
+            bubble.snapRight(platform);
             break;
           }
         }
@@ -260,15 +261,15 @@ public class CollisionsLevelModifier implements LevelModifier {
           Collision collision = new Collision(player, bubble, delta);
           if (collision.collidingFromTop() && !(bubble.hasNPC())) {
             player.getSpeed().setY(-Constants.PLAYER_JUMP);
-            kinetics.snapTop(player, bubble);
+            player.snapTop(bubble);
             break;
           }
 
           if (collision.colliding() && bubble.hasNPC()) {
             Fruit newFruit = null;
             try {
-              newFruit = new Fruit(bubble.getPosition().clone(), new Vector(Constants.BLOCKSIZE,
-                  Constants.BLOCKSIZE));
+              newFruit = new Fruit(bubble.getPosition().clone(),
+                  new Vector(Constants.BLOCKSIZE, Constants.BLOCKSIZE));
             } catch (CloneNotSupportedException e) {
               e.printStackTrace();
             }

--- a/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifier.java
@@ -17,7 +17,6 @@ import nl.tudelft.scrumbledore.powerup.PowerupPickUp;
     "PMD.NPathComplexity", "PMD.StdCyclomaticComplexity", "PMD.CyclomaticComplexity" })
 public class CollisionsLevelModifier implements LevelModifier {
 
-  private KineticsLevelModifier kinetics;
   private ScoreCounter score;
 
   /**
@@ -28,8 +27,7 @@ public class CollisionsLevelModifier implements LevelModifier {
    * @param score
    *          The Score Counter to be used.
    */
-  public CollisionsLevelModifier(KineticsLevelModifier kinetics, ScoreCounter score) {
-    this.kinetics = kinetics;
+  public CollisionsLevelModifier(ScoreCounter score) {
     this.score = score;
   }
 
@@ -403,15 +401,6 @@ public class CollisionsLevelModifier implements LevelModifier {
         }
       }
     }
-  }
-
-  /**
-   * Returns a KineticsLevelModifier.
-   * 
-   * @return The kinetics
-   */
-  public KineticsLevelModifier getKinetics() {
-    return kinetics;
   }
 
   /**

--- a/src/main/java/nl/tudelft/scrumbledore/level/KineticsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/KineticsLevelModifier.java
@@ -1,7 +1,5 @@
 package nl.tudelft.scrumbledore.level;
 
-import nl.tudelft.scrumbledore.Constants;
-
 /**
  * The Kinetics class handles the position/speed of levelelements.
  * 
@@ -23,7 +21,6 @@ public class KineticsLevelModifier implements LevelModifier {
     for (LevelElement element : level.getDynamicElements()) {
       move(element, d);
       applyFriction(element, d);
-      warp(element);
     }
   }
 
@@ -80,47 +77,6 @@ public class KineticsLevelModifier implements LevelModifier {
   public void revertMove(LevelElement el, double d) {
     if (el != null) {
       el.getPosition().difference(Vector.scale(el.getSpeed(), d));
-    }
-  }
-
-  /**
-   * Warp a LeveElement both in horizontal and vertical direction.
-   * 
-   * @param element
-   *          The LevelElement to be warped.
-   */
-  public void warp(LevelElement element) {
-    warpVertically(element);
-    warpHorizontally(element);
-  }
-
-  /**
-   * Warp a Level Element through the vertical boundaries of the level.
-   * 
-   * @param element
-   *          The Level Element to be warped.
-   */
-  public void warpVertically(LevelElement element) {
-    double offset = element.height() / 2;
-    if (element.posY() < -offset) {
-      element.getPosition().setY(Constants.LEVELY + offset);
-    } else if (element.posY() > Constants.LEVELY + offset) {
-      element.getPosition().setY(-offset);
-    }
-  }
-
-  /**
-   * Warp a Level Element through the horizontal boundaries of the level.
-   * 
-   * @param element
-   *          The Level Element to be warped.
-   */
-  public void warpHorizontally(LevelElement element) {
-    double offset = -element.width() / 2;
-    if (element.posX() < -offset) {
-      element.getPosition().setX(Constants.LEVELX + offset);
-    } else if (element.posX() > Constants.LEVELX + offset) {
-      element.getPosition().setX(-offset);
     }
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/level/KineticsLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/KineticsLevelModifier.java
@@ -43,12 +43,12 @@ public class KineticsLevelModifier implements LevelModifier {
     if (Math.abs(el.hSpeed()) > el.hFric() * d) {
       signX = (int) Math.signum(el.hSpeed());
     } else {
-      stopHorizontally(el);
+      el.stopHorizontally();
     }
     if (Math.abs(el.vSpeed()) > el.vFric() * d) {
       signY = (int) Math.signum(el.vSpeed());
     } else {
-      stopVertically(el);
+      el.stopVertically();
     }
 
     Vector fricDiff = new Vector(d * signX * el.hFric(), d * signY * el.vFric());
@@ -81,26 +81,6 @@ public class KineticsLevelModifier implements LevelModifier {
     if (el != null) {
       el.getPosition().difference(Vector.scale(el.getSpeed(), d));
     }
-  }
-
-  /**
-   * Stop a LevelElement's vertical movement.
-   * 
-   * @param element
-   *          The element.
-   */
-  public void stopVertically(LevelElement element) {
-    element.getSpeed().setY(0);
-  }
-
-  /**
-   * Stop a LevelElement's horizontal movement.
-   * 
-   * @param element
-   *          The element.
-   */
-  public void stopHorizontally(LevelElement element) {
-    element.getSpeed().setX(0);
   }
 
   /**
@@ -142,62 +122,6 @@ public class KineticsLevelModifier implements LevelModifier {
     } else if (element.posX() > Constants.LEVELX + offset) {
       element.getPosition().setX(-offset);
     }
-  }
-
-  /**
-   * Snap a LevelElement to the left side of another LevelElement.
-   * 
-   * @param snapper
-   *          The LevelElement to be snapped.
-   * @param snapTo
-   *          The LevelElement to be snapped to.
-   */
-  public void snapLeft(LevelElement snapper, LevelElement snapTo) {
-    double offset = snapper.getSize().getX() / 2;
-    double newPos = snapTo.getLeft() - offset;
-    snapper.getPosition().setX(newPos);
-  }
-
-  /**
-   * Snap a LevelElement to the right side of another LevelElement.
-   * 
-   * @param snapper
-   *          The LevelElement to be snapped.
-   * @param snapTo
-   *          The LevelElement to be snapped to.
-   */
-  public void snapRight(LevelElement snapper, LevelElement snapTo) {
-    double offset = snapper.getSize().getX() / 2;
-    double newPos = snapTo.getRight() + offset;
-    snapper.getPosition().setX(newPos);
-  }
-
-  /**
-   * Snap a LevelElement to the top side of another LevelElement.
-   * 
-   * @param snapper
-   *          The LevelElement to be snapped.
-   * @param snapTo
-   *          The LevelElement to be snapped to.
-   */
-  public void snapTop(LevelElement snapper, LevelElement snapTo) {
-    double offset = snapper.getSize().getY() / 2;
-    double newPos = snapTo.getTop() - offset;
-    snapper.getPosition().setY(newPos);
-  }
-
-  /**
-   * Snap a LevelElement to the bottom side of another LevelElement.
-   * 
-   * @param snapper
-   *          The LevelElement to be snapped.
-   * @param snapTo
-   *          The LevelElement to be snapped to.
-   */
-  public void snapBottom(LevelElement snapper, LevelElement snapTo) {
-    double offset = snapper.getSize().getY() / 2;
-    double newPos = snapTo.getBottom() + offset;
-    snapper.getPosition().setY(newPos);
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/level/Level.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/Level.java
@@ -40,15 +40,15 @@ public class Level {
    *          A LevelElement.
    */
   public void addElement(LevelElement element) {
-    if (element.getClass().equals(Platform.class)) {
+    if (element instanceof Platform) {
       platforms.add((Platform) element);
-    } else if (element.getClass().equals(NPC.class)) {
+    } else if (element instanceof NPC) {
       npcs.add((NPC) element);
-    } else if (element.getClass().equals(Fruit.class)) {
+    } else if (element instanceof Fruit) {
       fruits.add((Fruit) element);
-    } else if (element.getClass().equals(Player.class)) {
+    } else if (element instanceof Player) {
       players.add((Player) element);
-    } else if (element.getClass().equals(Bubble.class)) {
+    } else if (element instanceof Bubble) {
       bubbles.add((Bubble) element);
     } else if (element instanceof PowerupPickUp) {
       powerups.add((PowerupPickUp) element);
@@ -134,7 +134,7 @@ public class Level {
   public ArrayList<Bubble> getEnemyBubbles() {
     return encapEnemies;
   }
-  
+
   /**
    * Returns an ArrayList of Powerup objects.
    * 

--- a/src/main/java/nl/tudelft/scrumbledore/level/LevelElement.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/LevelElement.java
@@ -144,6 +144,20 @@ public abstract class LevelElement {
   }
 
   /**
+   * Stop this LevelElement's vertical movement.
+   */
+  public void stopVertically() {
+    getSpeed().setY(0);
+  }
+
+  /**
+   * Stop this LevelElement's horizontal movement.
+   */
+  public void stopHorizontally() {
+    getSpeed().setX(0);
+  }
+
+  /**
    * Check whether this LevelElement is affected by Gravity.
    * 
    * @return Boolean
@@ -216,7 +230,7 @@ public abstract class LevelElement {
    * @param other
    *          The other element.
    * @param range
-   *          The range (of the circal).
+   *          The range (of the circle).
    * @return A boolean.
    */
   public boolean inRadiusRangeOf(LevelElement other, double range) {
@@ -238,6 +252,54 @@ public abstract class LevelElement {
     boolean inX = (other.posX() >= posX() - range && other.posX() <= posX() + range);
     boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
     return inX && inY;
+  }
+
+  /**
+   * Snap a LevelElement to the left side of another LevelElement.
+   * 
+   * @param other
+   *          The LevelElement to be snapped to.
+   */
+  public void snapLeft(LevelElement other) {
+    double offset = getSize().getX() / 2;
+    double newPos = other.getLeft() - offset;
+    getPosition().setX(newPos);
+  }
+
+  /**
+   * Snap a LevelElement to the right side of another LevelElement.
+   * 
+   * @param other
+   *          The LevelElement to be snapped to.
+   */
+  public void snapRight(LevelElement other) {
+    double offset = getSize().getX() / 2;
+    double newPos = other.getRight() + offset;
+    getPosition().setX(newPos);
+  }
+
+  /**
+   * Snap a LevelElement to the top side of another LevelElement.
+   * 
+   * @param other
+   *          The LevelElement to be snapped to.
+   */
+  public void snapTop(LevelElement other) {
+    double offset = getSize().getY() / 2;
+    double newPos = other.getTop() - offset;
+    getPosition().setY(newPos);
+  }
+
+  /**
+   * Snap a LevelElement to the bottom side of another LevelElement.
+   * 
+   * @param other
+   *          The LevelElement to be snapped to.
+   */
+  public void snapBottom(LevelElement other) {
+    double offset = getSize().getY() / 2;
+    double newPos = other.getBottom() + offset;
+    getPosition().setY(newPos);
   }
 
   /**

--- a/src/main/java/nl/tudelft/scrumbledore/level/WarpLevelModifier.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/WarpLevelModifier.java
@@ -1,0 +1,69 @@
+package nl.tudelft.scrumbledore.level;
+
+import nl.tudelft.scrumbledore.Constants;
+
+/**
+ * LevelModifier responsible for warping LevelElements around the edges of the Level. (This used to
+ * be a responsibility of the KineticsLevelModifier.)
+ * 
+ * @author Jesse Tilro
+ *
+ */
+public class WarpLevelModifier implements LevelModifier {
+
+  /**
+   * Warp all dynamic element in a given Level.
+   * 
+   * @param level
+   *          The level to be modified.
+   * @param delta
+   *          The number of steps passed since the last cycle.
+   */
+  public void modify(Level level, double delta) {
+    for (LevelElement element : level.getDynamicElements()) {
+      warp(element);
+    }
+  }
+
+  /**
+   * Warp a LeveElement both in horizontal and vertical direction.
+   * 
+   * @param element
+   *          The LevelElement to be warped.
+   */
+  public void warp(LevelElement element) {
+    warpVertically(element);
+    warpHorizontally(element);
+  }
+
+  /**
+   * Warp a Level Element through the vertical boundaries of the level.
+   * 
+   * @param element
+   *          The Level Element to be warped.
+   */
+  public void warpVertically(LevelElement element) {
+    double offset = element.height() / 2;
+    if (element.posY() < -offset) {
+      element.getPosition().setY(Constants.LEVELY + offset);
+    } else if (element.posY() > Constants.LEVELY + offset) {
+      element.getPosition().setY(-offset);
+    }
+  }
+
+  /**
+   * Warp a Level Element through the horizontal boundaries of the level.
+   * 
+   * @param element
+   *          The Level Element to be warped.
+   */
+  public void warpHorizontally(LevelElement element) {
+    double offset = -element.width() / 2;
+    if (element.posX() < -offset) {
+      element.getPosition().setX(Constants.LEVELX + offset);
+    } else if (element.posX() > Constants.LEVELX + offset) {
+      element.getPosition().setX(-offset);
+    }
+  }
+
+}

--- a/src/test/java/nl/tudelft/scrumbledore/game/GameFactoryTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/game/GameFactoryTest.java
@@ -14,6 +14,7 @@ import nl.tudelft.scrumbledore.level.KineticsLevelModifier;
 import nl.tudelft.scrumbledore.level.LevelModifier;
 import nl.tudelft.scrumbledore.level.NPCLevelModifier;
 import nl.tudelft.scrumbledore.level.PlayerActionsLevelModifier;
+import nl.tudelft.scrumbledore.level.WarpLevelModifier;
 
 /**
  * Test suite for the GameFactory class.
@@ -23,7 +24,7 @@ import nl.tudelft.scrumbledore.level.PlayerActionsLevelModifier;
 public class GameFactoryTest {
 
   private GameFactory factory;
-  
+
   /**
    * Set-up the initial Game Factory.
    */
@@ -37,16 +38,17 @@ public class GameFactoryTest {
    */
   @Test
   public final void testMakeSinglePlayerGame() {
-    Game game = factory.makeSinglePlayerGame(); 
+    Game game = factory.makeSinglePlayerGame();
     ArrayList<LevelModifier> modifiers = game.getModifiers();
-    
-    assertEquals(6, modifiers.size());
+
+    assertEquals(7, modifiers.size());
     assertEquals(1, countLevelModifiers(PlayerActionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(GravityLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(NPCLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(BubbleActionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(CollisionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(KineticsLevelModifier.class, modifiers));
+    assertEquals(1, countLevelModifiers(WarpLevelModifier.class, modifiers));
   }
 
   /**
@@ -54,16 +56,17 @@ public class GameFactoryTest {
    */
   @Test
   public final void testMakeMultiPlayerGame() {
-    Game game = factory.makeMultiPlayerGame(); 
+    Game game = factory.makeMultiPlayerGame();
     ArrayList<LevelModifier> modifiers = game.getModifiers();
 
-    assertEquals(6, modifiers.size());
+    assertEquals(7, modifiers.size());
     assertEquals(1, countLevelModifiers(PlayerActionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(GravityLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(NPCLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(BubbleActionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(CollisionsLevelModifier.class, modifiers));
     assertEquals(1, countLevelModifiers(KineticsLevelModifier.class, modifiers));
+    assertEquals(1, countLevelModifiers(WarpLevelModifier.class, modifiers));
   }
 
   /**
@@ -73,18 +76,17 @@ public class GameFactoryTest {
    *          A class to counted
    * @param modifiers
    *          An ArrayList of LevelModifiers
-   * @return
-   *          The number of instances of an input object counted in the list of modifiers
+   * @return The number of instances of an input object counted in the list of modifiers
    */
   private static int countLevelModifiers(Class c, ArrayList<LevelModifier> modifiers) {
     int count = 0;
-    
+
     for (LevelModifier modifier : modifiers) {
       if (modifier.getClass() == c) {
         count++;
       }
     }
-    
+
     return count;
   }
 }

--- a/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
@@ -31,10 +31,9 @@ public class CollisionsLevelModifierTest {
    */
   @Before
   public void setUp() {
-    klm = mock(KineticsLevelModifier.class);
     sc = mock(ScoreCounter.class);
 
-    clm = new CollisionsLevelModifier(klm, sc);
+    clm = new CollisionsLevelModifier(sc);
   }
 
   /**
@@ -69,8 +68,7 @@ public class CollisionsLevelModifierTest {
     KineticsLevelModifier klm = new KineticsLevelModifier();
     ScoreCounter sc = new ScoreCounter();
 
-    CollisionsLevelModifier clm = new CollisionsLevelModifier(klm, sc);
-    assertEquals(klm, clm.getKinetics());
+    CollisionsLevelModifier clm = new CollisionsLevelModifier(sc);
     assertEquals(sc, clm.getScore());
   }
 

--- a/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/CollisionsLevelModifierTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +17,7 @@ import nl.tudelft.scrumbledore.game.ScoreCounter;
  * Test suite for the CollisionsLevelModifier class.
  * 
  * @author Niels Warnars
+ * @author Jesse Tilro
  */
 @SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "PMD.TooManyMethods",
     "PMD.TooManyStaticImports" })
@@ -33,6 +35,30 @@ public class CollisionsLevelModifierTest {
     sc = mock(ScoreCounter.class);
 
     clm = new CollisionsLevelModifier(klm, sc);
+  }
+
+  /**
+   * Helper method for stubbing a mocked dependency LevelElement class.
+   * 
+   * @param instance
+   *          The reference instance determining which class is to be mocked and how it should be
+   *          stubbed.
+   */
+  private LevelElement mockLevelElement(LevelElement instance) {
+    LevelElement mock = mock(instance.getClass());
+
+    when(mock.getPosition()).thenReturn(instance.getPosition());
+    when(mock.getSpeed()).thenReturn(instance.getSpeed());
+    when(mock.posX()).thenReturn(instance.posX());
+    when(mock.posY()).thenReturn(instance.posY());
+    when(mock.hSpeed()).thenReturn(instance.hSpeed());
+    when(mock.vSpeed()).thenReturn(instance.vSpeed());
+    when(mock.getLeft()).thenReturn(instance.getLeft());
+    when(mock.getRight()).thenReturn(instance.getRight());
+    when(mock.getTop()).thenReturn(instance.getTop());
+    when(mock.getBottom()).thenReturn(instance.getBottom());
+
+    return mock;
   }
 
   /**
@@ -56,13 +82,15 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 32), new Vector(32, 32));
     Fruit fruit = new Fruit(new Vector(0, 0), new Vector(32, 32));
     fruit.getSpeed().setY(4);
+    LevelElement fruitMock = mockLevelElement(fruit);
+
     Level level = new Level();
-    level.addElement(fruit);
+    level.addElement(fruitMock);
     level.addElement(platform);
 
     clm.detectFruitPlatform(level, 1);
-    verify(klm).stopVertically(fruit);
-    verify(klm).snapTop(fruit, platform);
+    verify(fruitMock).stopVertically();
+    verify(fruitMock).snapTop(platform);
   }
 
   /**
@@ -70,17 +98,19 @@ public class CollisionsLevelModifierTest {
    */
   @Test
   public void testDetectNPCPlatformFromTop() {
+    // Fixtures
     Platform platform = new Platform(new Vector(0, 32), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
-    npc.getSpeed().setY(4);
+    npc.getSpeed().setY(8);
+    LevelElement npcMock = mockLevelElement(npc);
 
     Level level = new Level();
     level.addElement(platform);
-    level.addElement(npc);
-
+    level.addElement(npcMock);
     clm.detectNPCPlatform(level, 1);
-    verify(klm).stopVertically(npc);
-    verify(klm).snapTop(npc, platform);
+
+    verify(npcMock).stopVertically();
+    verify(npcMock).snapTop(platform);
   }
 
   /**
@@ -91,15 +121,15 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(0, 0), new Vector(32, 32));
     npc.getSpeed().setX(4);
+    LevelElement npcMock = mockLevelElement(npc);
 
     Level level = new Level();
     level.addElement(platform);
-    level.addElement(npc);
+    level.addElement(npcMock);
 
     clm.detectNPCPlatform(level, 1);
-    verify(klm).stopHorizontally(npc);
-    verify(klm).snapLeft(npc, platform);
-    assertTrue(npc.hasAction(NPCAction.MoveLeft));
+    verify(npcMock).stopHorizontally();
+    verify(npcMock).snapLeft(platform);
   }
 
   /**
@@ -110,15 +140,15 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     NPC npc = new NPC(new Vector(32, 0), new Vector(32, 32));
     npc.getSpeed().setX(-4);
+    LevelElement npcMock = mockLevelElement(npc);
 
     Level level = new Level();
     level.addElement(platform);
-    level.addElement(npc);
+    level.addElement(npcMock);
 
     clm.detectNPCPlatform(level, 1);
-    verify(klm).stopHorizontally(npc);
-    verify(klm).snapRight(npc, platform);
-    assertTrue(npc.hasAction(NPCAction.MoveRight));
+    verify(npcMock).stopHorizontally();
+    verify(npcMock).snapRight(platform);
   }
 
   /**
@@ -129,14 +159,15 @@ public class CollisionsLevelModifierTest {
     Platform platform = new Platform(new Vector(0, 32), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     player.getSpeed().setY(4);
+    LevelElement playerMock = mockLevelElement(player);
 
     Level level = new Level();
-    level.addElement(player);
+    level.addElement(playerMock);
     level.addElement(platform);
 
     clm.detectPlayerPlatform(level, 1);
-    verify(klm).stopVertically(player);
-    verify(klm).snapTop(player, platform);
+    verify(playerMock).stopVertically();
+    verify(playerMock).snapTop(platform);
   }
 
   /**
@@ -145,16 +176,17 @@ public class CollisionsLevelModifierTest {
   @Test
   public void testDetectPlayerPlatformFromBottom() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
-    Player player = new Player(new Vector(0, 33), new Vector(32, 32));
+    Player player = new Player(new Vector(0, 32), new Vector(32, 32));
     player.getSpeed().setY(-4);
+    LevelElement playerMock = mockLevelElement(player);
 
     Level level = new Level();
-    level.addElement(player);
+    level.addElement(playerMock);
     level.addElement(platform);
 
     clm.detectPlayerPlatform(level, 1);
-    verify(klm).stopVertically(player);
-    verify(klm).snapBottom(player, platform);
+    verify(playerMock).stopVertically();
+    verify(playerMock).snapBottom(platform);
   }
 
   /**
@@ -164,15 +196,15 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerPlatformFromLeft() {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
-
     player.getSpeed().setX(4);
+    LevelElement playerMock = mockLevelElement(player);
 
     Level level = new Level();
-    level.addElement(player);
+    level.addElement(playerMock);
     level.addElement(platform);
 
     clm.detectPlayerPlatform(level, 1);
-    verify(klm).stopHorizontally(player);
+    verify(playerMock).stopHorizontally();
   }
 
   /**
@@ -182,15 +214,15 @@ public class CollisionsLevelModifierTest {
   public void testDetectPlayerPlatformFromRight() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     Player player = new Player(new Vector(32, 0), new Vector(32, 32));
-
     player.getSpeed().setX(-4);
+    LevelElement playerMock = mockLevelElement(player);
 
     Level level = new Level();
-    level.addElement(player);
+    level.addElement(playerMock);
     level.addElement(platform);
 
     clm.detectPlayerPlatform(level, 1);
-    verify(klm).stopHorizontally(player);
+    verify(playerMock).stopHorizontally();
   }
 
   /**
@@ -200,14 +232,15 @@ public class CollisionsLevelModifierTest {
   public void testDetectBubblePlatformFromBottom() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(0, 32), new Vector(32, 32));
+    LevelElement bubbleMock = mockLevelElement(bubble);
 
     Level level = new Level();
-    level.addElement(bubble);
+    level.addElement(bubbleMock);
     level.addElement(platform);
 
     clm.detectBubblePlatform(level, 1);
-    verify(klm).snapBottom(bubble, platform);
-    assertEquals(bubble.vSpeed(), Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
+    verify(bubbleMock).snapBottom(platform);
+    assertEquals(Constants.BUBBLE_BOUNCE, bubbleMock.getSpeed().getY(), Constants.DOUBLE_PRECISION);
   }
 
   /**
@@ -217,14 +250,16 @@ public class CollisionsLevelModifierTest {
   public void testDetectBubblePlatformFromLeft() {
     Platform platform = new Platform(new Vector(32, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(0, 0), new Vector(32, 32));
+    LevelElement bubbleMock = mockLevelElement(bubble);
 
     Level level = new Level();
-    level.addElement(bubble);
+    level.addElement(bubbleMock);
     level.addElement(platform);
 
     clm.detectBubblePlatform(level, 1);
-    verify(klm).snapLeft(bubble, platform);
-    assertEquals(bubble.hSpeed(), -Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
+    verify(bubbleMock).snapLeft(platform);
+    assertEquals(-Constants.BUBBLE_BOUNCE, bubbleMock.getSpeed().getX(),
+        Constants.DOUBLE_PRECISION);
   }
 
   /**
@@ -234,14 +269,15 @@ public class CollisionsLevelModifierTest {
   public void testDetectBubblePlatformFromRight() {
     Platform platform = new Platform(new Vector(0, 0), new Vector(32, 32));
     Bubble bubble = new Bubble(new Vector(32, 0), new Vector(32, 32));
+    LevelElement bubbleMock = mockLevelElement(bubble);
 
     Level level = new Level();
-    level.addElement(bubble);
+    level.addElement(bubbleMock);
     level.addElement(platform);
 
     clm.detectBubblePlatform(level, 1);
-    verify(klm).snapRight(bubble, platform);
-    assertEquals(bubble.hSpeed(), Constants.BUBBLE_BOUNCE, Constants.DOUBLE_PRECISION);
+    verify(bubbleMock).snapRight(platform);
+    assertEquals(Constants.BUBBLE_BOUNCE, bubbleMock.getSpeed().getX(), Constants.DOUBLE_PRECISION);
   }
 
   /**
@@ -252,14 +288,15 @@ public class CollisionsLevelModifierTest {
     Bubble bubble = new Bubble(new Vector(0, 32), new Vector(32, 32));
     Player player = new Player(new Vector(0, 0), new Vector(32, 32));
     player.getSpeed().setY(4);
+    LevelElement playerMock = mockLevelElement(player);
 
     Level level = new Level();
-    level.addElement(player);
+    level.addElement(playerMock);
     level.addElement(bubble);
 
     clm.detectPlayerBubble(level, 1);
-    verify(klm).snapTop(player, bubble);
-    assertEquals(-Constants.PLAYER_JUMP, player.vSpeed(), Constants.DOUBLE_PRECISION);
+    verify(playerMock).snapTop(bubble);
+    assertEquals(-Constants.PLAYER_JUMP, playerMock.getSpeed().getY(), Constants.DOUBLE_PRECISION);
   }
 
   /**

--- a/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.tudelft.scrumbledore.Constants;
-
 /**
  * Testing the Kinetics class.
  * 
@@ -118,58 +116,6 @@ public class KineticsLevelModifierTest {
   }
 
   /**
-   * When a Level Element has gotten outside the bottom of the level and is subsequently being
-   * warped, it should reappear just outside the top of the level with the same X coordinate.
-   */
-  @Test
-  public void testWarpVerticallyBottomToTop() {
-    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
-    el.getPosition().setY(Constants.LEVELY + 17);
-    kinetics.warpVertically(el);
-    assertEquals(-16, el.posY(), Constants.DOUBLE_PRECISION);
-    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * When a Level Element has gotten outside the top of the level and is subsequently being warped,
-   * it should reappear just outside the bottom of the level with the same X coordinate.
-   */
-  @Test
-  public void testWarpVerticallyTopToBottom() {
-    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
-    el.getPosition().setY(-17);
-    kinetics.warpVertically(el);
-    assertEquals(Constants.LEVELY + 16, el.posY(), Constants.DOUBLE_PRECISION);
-    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * When a Level Element has gotten outside the right side of the level and is subsequently being
-   * warped, it should reappear just outside the left side of the level with the same Y coordinate.
-   */
-  @Test
-  public void testWarpHorizontallyRightToLeft() {
-    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
-    el.getPosition().setX(Constants.LEVELX);
-    kinetics.warpHorizontally(el);
-    assertEquals(16, el.posX(), Constants.DOUBLE_PRECISION);
-    assertEquals(0, el.posY(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * When a Level Element has gotten outside the left side of the level and is subsequently being
-   * warped, it should reappear just outside the right side of the level with the same Y coordinate.
-   */
-  @Test
-  public void testWarpHorizontallyLeftToRight() {
-    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
-    el.getPosition().setX(0);
-    kinetics.warpHorizontally(el);
-    assertEquals(Constants.LEVELX - 16, el.posX(), Constants.DOUBLE_PRECISION);
-    assertEquals(0, el.posY(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
    * When a Level is modified, the position of the Player should be updated correctly.
    */
   @Test
@@ -179,23 +125,6 @@ public class KineticsLevelModifierTest {
     Level level = new Level();
     level.addElement(player);
     Vector expectedPosition = new Vector(2, 2);
-
-    kinetics.modify(level, .5);
-
-    assertEquals(expectedPosition, player.getPosition());
-  }
-
-  /**
-   * When a Level is modified and the Player is moving outside the bottom of the Level, the Player
-   * should be warped to the top of the Level.
-   */
-  @Test
-  public void testModifyPlayerWarp() {
-    Player player = new Player(new Vector(0, Constants.LEVELY), new Vector(0, 0));
-    player.getSpeed().sum(new Vector(4, 4));
-    Level level = new Level();
-    level.addElement(player);
-    Vector expectedPosition = new Vector(2, 0);
 
     kinetics.modify(level, .5);
 

--- a/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/KineticsLevelModifierTest.java
@@ -118,28 +118,6 @@ public class KineticsLevelModifierTest {
   }
 
   /**
-   * When stopping a Level Element horizontally, its horizontal speed should be zero.
-   */
-  @Test
-  public void testStopHorizontally() {
-    LevelElement el = new Bubble(new Vector(0, 0), new Vector(0, 0));
-    el.getSpeed().setX(42);
-    kinetics.stopHorizontally(el);
-    assertEquals(0, el.getSpeed().getX(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * When stopping a Level Element vertically, its vertical speed should be zero.
-   */
-  @Test
-  public void testStopVertically() {
-    LevelElement el = new Bubble(new Vector(0, 0), new Vector(0, 0));
-    el.getSpeed().setY(42);
-    kinetics.stopVertically(el);
-    assertEquals(0, el.getSpeed().getY(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
    * When a Level Element has gotten outside the bottom of the level and is subsequently being
    * warped, it should reappear just outside the top of the level with the same X coordinate.
    */
@@ -189,62 +167,6 @@ public class KineticsLevelModifierTest {
     kinetics.warpHorizontally(el);
     assertEquals(Constants.LEVELX - 16, el.posX(), Constants.DOUBLE_PRECISION);
     assertEquals(0, el.posY(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * The LevelElement should be correctly snapped the left side of another one using the snapLeft
-   * method.
-   */
-  @Test
-  public void testSnapLeft() {
-    LevelElement snapper = new Player(new Vector(0, 0), new Vector(32, 32));
-    LevelElement snapTo = new Platform(new Vector(64, 0), new Vector(32, 32));
-
-    kinetics.snapLeft(snapper, snapTo);
-
-    assertEquals(32, snapper.getPosition().getX(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * The LevelElement should be correctly snapped the right side of another one using the snapRight
-   * method.
-   */
-  @Test
-  public void testSnapRight() {
-    LevelElement snapper = new Player(new Vector(64, 0), new Vector(32, 32));
-    LevelElement snapTo = new Platform(new Vector(0, 0), new Vector(32, 32));
-
-    kinetics.snapRight(snapper, snapTo);
-
-    assertEquals(32, snapper.getPosition().getX(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * The LevelElement should be correctly snapped the top side of another one using the snapTop
-   * method.
-   */
-  @Test
-  public void testSnapTop() {
-    LevelElement snapper = new Player(new Vector(0, 0), new Vector(32, 32));
-    LevelElement snapTo = new Platform(new Vector(0, 64), new Vector(32, 32));
-
-    kinetics.snapTop(snapper, snapTo);
-
-    assertEquals(32, snapper.getPosition().getY(), Constants.DOUBLE_PRECISION);
-  }
-
-  /**
-   * The LevelElement should be correctly snapped the top side of another one using the snapTop
-   * method.
-   */
-  @Test
-  public void testSnapBottom() {
-    LevelElement snapper = new Player(new Vector(0, 64), new Vector(32, 32));
-    LevelElement snapTo = new Platform(new Vector(0, 0), new Vector(32, 32));
-
-    kinetics.snapBottom(snapper, snapTo);
-
-    assertEquals(32, snapper.getPosition().getY(), Constants.DOUBLE_PRECISION);
   }
 
   /**

--- a/src/test/java/nl/tudelft/scrumbledore/level/LevelElementTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/LevelElementTest.java
@@ -232,6 +232,84 @@ public abstract class LevelElementTest {
   }
 
   /**
+   * When stopping a Level Element horizontally, its horizontal speed should be zero.
+   */
+  @Test
+  public void testStopHorizontally() {
+    LevelElement el = new Bubble(new Vector(0, 0), new Vector(0, 0));
+    el.getSpeed().setX(42);
+    el.stopHorizontally();
+    assertEquals(0, el.getSpeed().getX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When stopping a Level Element vertically, its vertical speed should be zero.
+   */
+  @Test
+  public void testStopVertically() {
+    LevelElement el = new Bubble(new Vector(0, 0), new Vector(0, 0));
+    el.getSpeed().setY(42);
+    el.stopVertically();
+    assertEquals(0, el.getSpeed().getY(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * The LevelElement should be correctly snapped the left side of another one using the snapLeft
+   * method.
+   */
+  @Test
+  public void testSnapLeft() {
+    LevelElement snapper = new Player(new Vector(0, 0), new Vector(32, 32));
+    LevelElement snapTo = new Platform(new Vector(64, 0), new Vector(32, 32));
+
+    snapper.snapLeft(snapTo);
+
+    assertEquals(32, snapper.getPosition().getX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * The LevelElement should be correctly snapped the right side of another one using the snapRight
+   * method.
+   */
+  @Test
+  public void testSnapRight() {
+    LevelElement snapper = new Player(new Vector(64, 0), new Vector(32, 32));
+    LevelElement snapTo = new Platform(new Vector(0, 0), new Vector(32, 32));
+
+    snapper.snapRight(snapTo);
+
+    assertEquals(32, snapper.getPosition().getX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * The LevelElement should be correctly snapped the top side of another one using the snapTop
+   * method.
+   */
+  @Test
+  public void testSnapTop() {
+    LevelElement snapper = new Player(new Vector(0, 0), new Vector(32, 32));
+    LevelElement snapTo = new Platform(new Vector(0, 64), new Vector(32, 32));
+
+    snapper.snapTop(snapTo);
+
+    assertEquals(32, snapper.getPosition().getY(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * The LevelElement should be correctly snapped the top side of another one using the snapTop
+   * method.
+   */
+  @Test
+  public void testSnapBottom() {
+    LevelElement snapper = new Player(new Vector(0, 64), new Vector(32, 32));
+    LevelElement snapTo = new Platform(new Vector(0, 0), new Vector(32, 32));
+
+    snapper.snapBottom(snapTo);
+
+    assertEquals(32, snapper.getPosition().getY(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
    * Cleaning up test properties after testing.
    */
   @After

--- a/src/test/java/nl/tudelft/scrumbledore/level/PlayerTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/PlayerTest.java
@@ -111,7 +111,7 @@ public class PlayerTest extends LevelElementTest {
     player.setPlayerNumber(42);
     assertEquals(42, player.getPlayerNumber());
   }
-  
+
   /**
    * Test the lastMove field getter/setter.
    */
@@ -162,5 +162,5 @@ public class PlayerTest extends LevelElementTest {
   public void testHashCode() {
     assertEquals(0, player.hashCode());
   }
-  
+
 }

--- a/src/test/java/nl/tudelft/scrumbledore/level/WarpLevelModifierTest.java
+++ b/src/test/java/nl/tudelft/scrumbledore/level/WarpLevelModifierTest.java
@@ -1,0 +1,96 @@
+package nl.tudelft.scrumbledore.level;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import nl.tudelft.scrumbledore.Constants;
+
+/**
+ * Test suite for the WarpLevelModifier class.
+ * 
+ * @author Jesse Tilro
+ *
+ */
+public class WarpLevelModifierTest {
+
+  private WarpLevelModifier warp;
+
+  /**
+   * Set up the test object.
+   */
+  @Before
+  public void setUp() {
+    warp = new WarpLevelModifier();
+  }
+
+  /**
+   * When a Level Element has gotten outside the bottom of the level and is subsequently being
+   * warped, it should reappear just outside the top of the level with the same X coordinate.
+   */
+  @Test
+  public void testWarpVerticallyBottomToTop() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setY(Constants.LEVELY + 17);
+    warp.warpVertically(el);
+    assertEquals(-16, el.posY(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When a Level Element has gotten outside the top of the level and is subsequently being warped,
+   * it should reappear just outside the bottom of the level with the same X coordinate.
+   */
+  @Test
+  public void testWarpVerticallyTopToBottom() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setY(-17);
+    warp.warpVertically(el);
+    assertEquals(Constants.LEVELY + 16, el.posY(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posX(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When a Level Element has gotten outside the right side of the level and is subsequently being
+   * warped, it should reappear just outside the left side of the level with the same Y coordinate.
+   */
+  @Test
+  public void testWarpHorizontallyRightToLeft() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setX(Constants.LEVELX);
+    warp.warpHorizontally(el);
+    assertEquals(16, el.posX(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posY(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When a Level Element has gotten outside the left side of the level and is subsequently being
+   * warped, it should reappear just outside the right side of the level with the same Y coordinate.
+   */
+  @Test
+  public void testWarpHorizontallyLeftToRight() {
+    LevelElement el = new Fruit(new Vector(0, 0), new Vector(32, 32));
+    el.getPosition().setX(0);
+    warp.warpHorizontally(el);
+    assertEquals(Constants.LEVELX - 16, el.posX(), Constants.DOUBLE_PRECISION);
+    assertEquals(0, el.posY(), Constants.DOUBLE_PRECISION);
+  }
+
+  /**
+   * When a Level is modified and the Player is moving outside the bottom of the Level, the Player
+   * should be warped to the top of the Level.
+   */
+  @Test
+  public void testModifyPlayerWarp() {
+    Player player = new Player(new Vector(0, Constants.LEVELY + 1), new Vector(0, 0));
+    Level level = new Level();
+    level.addElement(player);
+    Vector expectedPosition = new Vector(0, 0);
+
+    warp.modify(level, .5);
+
+    assertEquals(expectedPosition, player.getPosition());
+  }
+
+}


### PR DESCRIPTION
Moved the stopping and snapping functionality to the LevelElement class
itself. Reengineered the CollisionsLevelModifier test suite to support
this by use of extensive stubbing of LevelElement behavior.

The Collisions Level Modifier no longer needs a Kinetics Level Modifier,
so now all Level Modifier have no interrelations.

Moved the Warping to a new Level Modifier called WarpLevelModifier.

Relates to issue #226.
<organisation,testing
