### PR TITLE
Refactor powerups to conform to Decorator DP.

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/powerup/BlueberryBubble.java
+++ b/src/main/java/nl/tudelft/scrumbledore/powerup/BlueberryBubble.java
@@ -2,11 +2,9 @@ package nl.tudelft.scrumbledore.powerup;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.level.DynamicElement;
 import nl.tudelft.scrumbledore.level.LevelElement;
 import nl.tudelft.scrumbledore.level.LevelElementAction;
-import nl.tudelft.scrumbledore.level.Player;
 import nl.tudelft.scrumbledore.level.Vector;
 import nl.tudelft.scrumbledore.sprite.Sprite;
 import nl.tudelft.scrumbledore.sprite.SpriteStore;
@@ -20,37 +18,62 @@ import nl.tudelft.scrumbledore.sprite.SpriteStore;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class BlueberryBubble implements Powerup {
-  
-  private Vector position;
-  private Vector size;
-  private Vector speed;
-  private Vector friction;
-  private boolean gravity;
-  private ArrayList<LevelElementAction> actions;
-  private LevelElementAction lastMove;
-  private Boolean firing;
-  private Boolean alive;
-  private int id;
-  
-  private DynamicElement player;
+
+  private DynamicElement wrapped;
 
   /**
    * Create a new LevelElement instance.
    * 
-   * @param player , the wrapped object.
+   * @param wrapped
+   *          The DynamicElement to be wrapped in this Powerup Decorator.
    */
-  public BlueberryBubble(DynamicElement player) {
-    this.position = player.getPosition();
-    this.size = player.getSize();
-    this.speed = player.getSpeed();
-    this.friction = new Vector(0, 0);
-    setGravity(true);
+  public BlueberryBubble(DynamicElement wrapped) {
+    this.wrapped = wrapped;
+  }
 
-    id = 0;
-    actions = player.getActions();
-    lastMove = player.getLastMove();
-    firing = player.isFiring();
-    alive = player.isAlive();
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    ArrayList<Sprite> sprites = new ArrayList<Sprite>();
+    SpriteStore store = SpriteStore.getInstance();
+    sprites.add(store.getAnimated("fire-blue").getFrame(steps));
+    sprites.addAll(wrapped.getSprites(steps));
+    return sprites;
+  }
+
+  /**
+   * Decrease the lifetime by a given number of steps.
+   * 
+   * @param delta
+   *          The number of steps.
+   */
+  public void decreaseLifetime(double delta) {
+    wrapped.decreaseLifetime(delta);
+  }
+
+  /**
+   * Get the remaining lifetime.
+   * 
+   * @return Remaining lifetime.
+   */
+  public double getLifetime() {
+    return wrapped.getLifetime();
+  }
+
+  /**
+   * Setting the life time of a bubble.
+   * 
+   * @param newTime
+   *          The new life time.
+   */
+  public void setLifetime(double newTime) {
+    wrapped.setLifetime(newTime);
   }
 
   /**
@@ -59,7 +82,7 @@ public class BlueberryBubble implements Powerup {
    * @return Position Vector.
    */
   public Vector getPosition() {
-    return position;
+    return wrapped.getPosition();
   }
 
   /**
@@ -68,7 +91,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double posX() {
-    return position.getX();
+    return wrapped.posX();
   }
 
   /**
@@ -77,7 +100,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double posY() {
-    return position.getY();
+    return wrapped.posY();
   }
 
   /**
@@ -86,7 +109,7 @@ public class BlueberryBubble implements Powerup {
    * @return Size Vector.
    */
   public Vector getSize() {
-    return size;
+    return wrapped.getSize();
   }
 
   /**
@@ -95,7 +118,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double width() {
-    return size.getX();
+    return wrapped.width();
   }
 
   /**
@@ -104,7 +127,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double height() {
-    return size.getY();
+    return wrapped.height();
   }
 
   /**
@@ -113,7 +136,7 @@ public class BlueberryBubble implements Powerup {
    * @return Speed Vector.
    */
   public Vector getSpeed() {
-    return speed;
+    return wrapped.getSpeed();
   }
 
   /**
@@ -122,7 +145,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double hSpeed() {
-    return speed.getX();
+    return wrapped.hSpeed();
   }
 
   /**
@@ -131,7 +154,7 @@ public class BlueberryBubble implements Powerup {
    * @return double
    */
   public double vSpeed() {
-    return speed.getY();
+    return wrapped.vSpeed();
   }
 
   /**
@@ -140,7 +163,7 @@ public class BlueberryBubble implements Powerup {
    * @return Friction Vector.
    */
   public Vector getFriction() {
-    return friction;
+    return wrapped.getFriction();
   }
 
   /**
@@ -149,7 +172,7 @@ public class BlueberryBubble implements Powerup {
    * @return Horizontal friction.
    */
   public double hFric() {
-    return friction.getX();
+    return wrapped.hFric();
   }
 
   /**
@@ -158,21 +181,21 @@ public class BlueberryBubble implements Powerup {
    * @return Vertical friction.
    */
   public double vFric() {
-    return friction.getY();
+    return wrapped.vFric();
   }
 
   /**
    * Stop this LevelElement's vertical movement.
    */
   public void stopVertically() {
-    getSpeed().setY(0);
+    wrapped.stopVertically();
   }
 
   /**
    * Stop this LevelElement's horizontal movement.
    */
   public void stopHorizontally() {
-    getSpeed().setX(0);
+    wrapped.stopHorizontally();
   }
 
   /**
@@ -181,7 +204,7 @@ public class BlueberryBubble implements Powerup {
    * @return Boolean
    */
   public boolean hasGravity() {
-    return gravity;
+    return wrapped.hasGravity();
   }
 
   /**
@@ -191,7 +214,7 @@ public class BlueberryBubble implements Powerup {
    *          A boolean
    */
   public void setGravity(boolean gravity) {
-    this.gravity = gravity;
+    wrapped.setGravity(gravity);
   }
 
   /**
@@ -200,7 +223,7 @@ public class BlueberryBubble implements Powerup {
    * @return Y-coordinate of top.
    */
   public double getTop() {
-    return position.getY() - size.getY() / 2;
+    return wrapped.getTop();
   }
 
   /**
@@ -209,7 +232,7 @@ public class BlueberryBubble implements Powerup {
    * @return Y-coordinate of bottom.
    */
   public double getBottom() {
-    return position.getY() + size.getY() / 2;
+    return wrapped.getBottom();
   }
 
   /**
@@ -218,7 +241,7 @@ public class BlueberryBubble implements Powerup {
    * @return X-coordinate of left side.
    */
   public double getLeft() {
-    return position.getX() - size.getX() / 2;
+    return wrapped.getLeft();
   }
 
   /**
@@ -227,7 +250,7 @@ public class BlueberryBubble implements Powerup {
    * @return X-coordinate of right side.
    */
   public double getRight() {
-    return position.getX() + size.getX() / 2;
+    return wrapped.getRight();
   }
 
   /**
@@ -238,7 +261,7 @@ public class BlueberryBubble implements Powerup {
    * @return The distance.
    */
   public double distance(LevelElement other) {
-    return getPosition().distance(other.getPosition());
+    return wrapped.distance(other);
   }
 
   /**
@@ -252,7 +275,7 @@ public class BlueberryBubble implements Powerup {
    * @return A boolean.
    */
   public boolean inRadiusRangeOf(LevelElement other, double range) {
-    return distance(other) <= range;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -267,9 +290,7 @@ public class BlueberryBubble implements Powerup {
    * @return A boolean.
    */
   public boolean inBoxRangeOf(LevelElement other, double range) {
-    boolean inX = (other.posX() >= posX() - range && other.posX() <= posX() + range);
-    boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
-    return inX && inY;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -279,9 +300,7 @@ public class BlueberryBubble implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapLeft(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getLeft() - offset;
-    getPosition().setX(newPos);
+    wrapped.snapLeft(other);
   }
 
   /**
@@ -291,9 +310,7 @@ public class BlueberryBubble implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapRight(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getRight() + offset;
-    getPosition().setX(newPos);
+    wrapped.snapRight(other);
   }
 
   /**
@@ -303,9 +320,7 @@ public class BlueberryBubble implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapTop(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getTop() - offset;
-    getPosition().setY(newPos);
+    wrapped.snapTop(other);
   }
 
   /**
@@ -315,38 +330,33 @@ public class BlueberryBubble implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapBottom(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getBottom() + offset;
-    getPosition().setY(newPos);
+    wrapped.snapBottom(other);
   }
 
   /**
    * Add an action to be performed in the next step.
    * 
    * @param action
-   *          A PlayerAction
+   *          A LevelElementAction
    */
   public void addAction(LevelElementAction action) {
-    if (!hasAction(action)) {
-      actions.add(action);
-      setLastMove(action);
-    }
+    wrapped.addAction(action);
   }
 
   /**
    * Remove all actions from the queue.
    */
   public void clearActions() {
-    actions.clear();
+    wrapped.clearActions();
   }
 
   /**
-   * Checking wether the player is alive.
+   * Checking whether the player is alive.
    * 
    * @return The boolean if the player is alive.
    */
   public Boolean isAlive() {
-    return alive;
+    return wrapped.isAlive();
   }
 
   /**
@@ -356,7 +366,7 @@ public class BlueberryBubble implements Powerup {
    *          Can be True or False, stated on situation of player.
    */
   public void setAlive(Boolean bool) {
-    alive = bool;
+    wrapped.setAlive(bool);
   }
 
   /**
@@ -365,7 +375,7 @@ public class BlueberryBubble implements Powerup {
    * @return Integer that represents the players number in the game.
    */
   public int getPlayerNumber() {
-    return id;
+    return wrapped.getPlayerNumber();
   }
 
   /**
@@ -375,28 +385,28 @@ public class BlueberryBubble implements Powerup {
    *          Integer that represents the players number in the game.
    */
   public void setPlayerNumber(int id) {
-    this.id = id;
+    wrapped.setPlayerNumber(id);
   }
 
   /**
    * Check whether the given action is queued for the next step.
    * 
    * @param action
-   *          A PlayerAction.
+   *          A LevelElementAction.
    * @return Boolean.
    */
   public boolean hasAction(LevelElementAction action) {
-    return actions.contains(action);
+    return wrapped.hasAction(action);
   }
 
   /**
    * Remove the given action from the actions queue.
    * 
    * @param action
-   *          A PlayerAction.
+   *          A LevelElementAction.
    */
   public void removeAction(LevelElementAction action) {
-    actions.remove(action);
+    wrapped.removeAction(action);
   }
 
   /**
@@ -405,7 +415,7 @@ public class BlueberryBubble implements Powerup {
    * @return The last move performed.
    */
   public LevelElementAction getLastMove() {
-    return lastMove;
+    return wrapped.getLastMove();
   }
 
   /**
@@ -415,24 +425,17 @@ public class BlueberryBubble implements Powerup {
    *          The last move action performed.
    */
   public void setLastMove(LevelElementAction action) {
-    if (action == LevelElementAction.MoveLeft || action == LevelElementAction.MoveRight) {
-      lastMove = action;
-    }
+    wrapped.setLastMove(action);
   }
 
   @Override
   public int hashCode() {
-    return 0;
+    return wrapped.hashCode();
   }
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof BlueberryBubble) {
-      BlueberryBubble that = (BlueberryBubble) other;
-      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
-    }
-
-    return false;
+    return wrapped.equals(other);
   }
 
   /**
@@ -441,7 +444,7 @@ public class BlueberryBubble implements Powerup {
    * @return whether the Player is firing
    */
   public Boolean isFiring() {
-    return firing;
+    return wrapped.isFiring();
   }
 
   /**
@@ -451,75 +454,16 @@ public class BlueberryBubble implements Powerup {
    *          whether the Player is firing
    */
   public void setFiring(Boolean isFiring) {
-    this.firing = isFiring;
-  }
-
-  /**
-   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
-   * Element.
-   * 
-   * @param steps
-   *          The absolute exact number of steps since the game was started.
-   * @return Sprites to be drawn.
-   */
-  public ArrayList<Sprite> getSprites(double steps) {
-    ArrayList<Sprite> result = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    if (alive) {
-      boolean toRight = getLastMove() == LevelElementAction.MoveRight;
-
-      String id = "move-left";
-      if (firing && toRight) {
-        id = "shoot-right";
-      } else if (firing) {
-        id = "shoot-left";
-      } else if (toRight) {
-        id = "move-right";
-      }
-      if (getSpeed().getX() == 0 && !firing) {
-        steps = 0;
-      }
-
-      id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
-
-      result.add(store.getAnimated("fire-blue").getFrame(steps));
-      result.add(store.getAnimated(id).getFrame(steps));
-    }
-    return result;
+    wrapped.setFiring(isFiring);
   }
 
   /**
    * Gives a list of current actions of the player.
+   * 
    * @return a list of actions
    */
   public ArrayList<LevelElementAction> getActions() {
-    return actions;
-  }
-  
-  /**
-   * Decrease the lifetime by a given number of steps.
-   * 
-   * @param delta
-   *          The number of steps.
-   */
-  public void decreaseLifetime(double delta) {
+    return wrapped.getActions();
   }
 
-  /**
-   * Get the remaining lifetime.
-   * 
-   * @return Remaining lifetime.
-   */
-  public double getLifetime() {
-    return 0;
-  }
-
-  /**
-   * Setting the life time of a bubble.
-   * 
-   * @param newTime
-   *          The new life time.
-   */
-  public void setLifetime(double newTime) {
-  }
 }

--- a/src/main/java/nl/tudelft/scrumbledore/powerup/ChiliChicken.java
+++ b/src/main/java/nl/tudelft/scrumbledore/powerup/ChiliChicken.java
@@ -2,10 +2,8 @@ package nl.tudelft.scrumbledore.powerup;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.level.DynamicElement;
 import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Player;
 import nl.tudelft.scrumbledore.level.LevelElementAction;
 import nl.tudelft.scrumbledore.level.Vector;
 import nl.tudelft.scrumbledore.sprite.Sprite;
@@ -20,39 +18,34 @@ import nl.tudelft.scrumbledore.sprite.SpriteStore;
 @SuppressWarnings("PMD.TooManyMethods")
 public class ChiliChicken implements Powerup {
 
-  private Vector position;
-  private Vector size;
-  private Vector speed;
-  private Vector friction;
-  private boolean gravity;
-  private ArrayList<LevelElementAction> actions;
-  private LevelElementAction lastMove;
-  private Boolean firing;
-  private Boolean alive;
-  private int id;
-  private double lifetime;
+  private DynamicElement wrapped;
 
   /**
    * Create a new LevelElement instance.
    * 
-   * @param player , the object to be wrapped.
+   * @param wrapped
+   *          The DynamicElement to be wrapped in this Powerup Decorator.
    */
-  public ChiliChicken(DynamicElement player) {
-    this.position = player.getPosition();
-    this.size = player.getSize();
-    this.speed = player.getSpeed();
-    this.lifetime = Constants.CHILI_LIFETIME;
-    
-    this.friction = new Vector(0, 0);
-    setGravity(true);
-
-    id = 0;
-    actions = player.getActions();
-    lastMove = player.getLastMove();
-    firing = player.isFiring();
-    alive = player.isAlive();
+  public ChiliChicken(DynamicElement wrapped) {
+    this.wrapped = wrapped;
   }
-  
+
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    ArrayList<Sprite> sprites = new ArrayList<Sprite>();
+    SpriteStore store = SpriteStore.getInstance();
+    sprites.add(store.getAnimated("fire-yellow").getFrame(steps));
+    sprites.addAll(wrapped.getSprites(steps));
+    return sprites;
+  }
+
   /**
    * Decrease the lifetime by a given number of steps.
    * 
@@ -60,7 +53,7 @@ public class ChiliChicken implements Powerup {
    *          The number of steps.
    */
   public void decreaseLifetime(double delta) {
-    lifetime -= delta;
+    wrapped.decreaseLifetime(delta);
   }
 
   /**
@@ -69,7 +62,7 @@ public class ChiliChicken implements Powerup {
    * @return Remaining lifetime.
    */
   public double getLifetime() {
-    return lifetime;
+    return wrapped.getLifetime();
   }
 
   /**
@@ -79,7 +72,7 @@ public class ChiliChicken implements Powerup {
    *          The new life time.
    */
   public void setLifetime(double newTime) {
-    lifetime = newTime;
+    wrapped.setLifetime(newTime);
   }
 
   /**
@@ -88,7 +81,7 @@ public class ChiliChicken implements Powerup {
    * @return Position Vector.
    */
   public Vector getPosition() {
-    return position;
+    return wrapped.getPosition();
   }
 
   /**
@@ -97,7 +90,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double posX() {
-    return position.getX();
+    return wrapped.posX();
   }
 
   /**
@@ -106,7 +99,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double posY() {
-    return position.getY();
+    return wrapped.posY();
   }
 
   /**
@@ -115,7 +108,7 @@ public class ChiliChicken implements Powerup {
    * @return Size Vector.
    */
   public Vector getSize() {
-    return size;
+    return wrapped.getSize();
   }
 
   /**
@@ -124,7 +117,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double width() {
-    return size.getX();
+    return wrapped.width();
   }
 
   /**
@@ -133,7 +126,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double height() {
-    return size.getY();
+    return wrapped.height();
   }
 
   /**
@@ -142,7 +135,7 @@ public class ChiliChicken implements Powerup {
    * @return Speed Vector.
    */
   public Vector getSpeed() {
-    return speed;
+    return wrapped.getSpeed();
   }
 
   /**
@@ -151,7 +144,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double hSpeed() {
-    return speed.getX();
+    return wrapped.hSpeed();
   }
 
   /**
@@ -160,7 +153,7 @@ public class ChiliChicken implements Powerup {
    * @return double
    */
   public double vSpeed() {
-    return speed.getY();
+    return wrapped.vSpeed();
   }
 
   /**
@@ -169,7 +162,7 @@ public class ChiliChicken implements Powerup {
    * @return Friction Vector.
    */
   public Vector getFriction() {
-    return friction;
+    return wrapped.getFriction();
   }
 
   /**
@@ -178,7 +171,7 @@ public class ChiliChicken implements Powerup {
    * @return Horizontal friction.
    */
   public double hFric() {
-    return friction.getX();
+    return wrapped.hFric();
   }
 
   /**
@@ -187,21 +180,21 @@ public class ChiliChicken implements Powerup {
    * @return Vertical friction.
    */
   public double vFric() {
-    return friction.getY();
+    return wrapped.vFric();
   }
 
   /**
    * Stop this LevelElement's vertical movement.
    */
   public void stopVertically() {
-    getSpeed().setY(0);
+    wrapped.stopVertically();
   }
 
   /**
    * Stop this LevelElement's horizontal movement.
    */
   public void stopHorizontally() {
-    getSpeed().setX(0);
+    wrapped.stopHorizontally();
   }
 
   /**
@@ -210,7 +203,7 @@ public class ChiliChicken implements Powerup {
    * @return Boolean
    */
   public boolean hasGravity() {
-    return gravity;
+    return wrapped.hasGravity();
   }
 
   /**
@@ -220,7 +213,7 @@ public class ChiliChicken implements Powerup {
    *          A boolean
    */
   public void setGravity(boolean gravity) {
-    this.gravity = gravity;
+    wrapped.setGravity(gravity);
   }
 
   /**
@@ -229,7 +222,7 @@ public class ChiliChicken implements Powerup {
    * @return Y-coordinate of top.
    */
   public double getTop() {
-    return position.getY() - size.getY() / 2;
+    return wrapped.getTop();
   }
 
   /**
@@ -238,7 +231,7 @@ public class ChiliChicken implements Powerup {
    * @return Y-coordinate of bottom.
    */
   public double getBottom() {
-    return position.getY() + size.getY() / 2;
+    return wrapped.getBottom();
   }
 
   /**
@@ -247,7 +240,7 @@ public class ChiliChicken implements Powerup {
    * @return X-coordinate of left side.
    */
   public double getLeft() {
-    return position.getX() - size.getX() / 2;
+    return wrapped.getLeft();
   }
 
   /**
@@ -256,7 +249,7 @@ public class ChiliChicken implements Powerup {
    * @return X-coordinate of right side.
    */
   public double getRight() {
-    return position.getX() + size.getX() / 2;
+    return wrapped.getRight();
   }
 
   /**
@@ -267,7 +260,7 @@ public class ChiliChicken implements Powerup {
    * @return The distance.
    */
   public double distance(LevelElement other) {
-    return getPosition().distance(other.getPosition());
+    return wrapped.distance(other);
   }
 
   /**
@@ -281,7 +274,7 @@ public class ChiliChicken implements Powerup {
    * @return A boolean.
    */
   public boolean inRadiusRangeOf(LevelElement other, double range) {
-    return distance(other) <= range;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -296,9 +289,7 @@ public class ChiliChicken implements Powerup {
    * @return A boolean.
    */
   public boolean inBoxRangeOf(LevelElement other, double range) {
-    boolean inX = (other.posX() >= posX() - range && other.posX() <= posX() + range);
-    boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
-    return inX && inY;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -308,9 +299,7 @@ public class ChiliChicken implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapLeft(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getLeft() - offset;
-    getPosition().setX(newPos);
+    wrapped.snapLeft(other);
   }
 
   /**
@@ -320,9 +309,7 @@ public class ChiliChicken implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapRight(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getRight() + offset;
-    getPosition().setX(newPos);
+    wrapped.snapRight(other);
   }
 
   /**
@@ -332,9 +319,7 @@ public class ChiliChicken implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapTop(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getTop() - offset;
-    getPosition().setY(newPos);
+    wrapped.snapTop(other);
   }
 
   /**
@@ -344,9 +329,7 @@ public class ChiliChicken implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapBottom(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getBottom() + offset;
-    getPosition().setY(newPos);
+    wrapped.snapBottom(other);
   }
 
   /**
@@ -356,26 +339,23 @@ public class ChiliChicken implements Powerup {
    *          A LevelElementAction
    */
   public void addAction(LevelElementAction action) {
-    if (!hasAction(action)) {
-      actions.add(action);
-      setLastMove(action);
-    }
+    wrapped.addAction(action);
   }
 
   /**
    * Remove all actions from the queue.
    */
   public void clearActions() {
-    actions.clear();
+    wrapped.clearActions();
   }
 
   /**
-   * Checking wether the player is alive.
+   * Checking whether the player is alive.
    * 
    * @return The boolean if the player is alive.
    */
   public Boolean isAlive() {
-    return alive;
+    return wrapped.isAlive();
   }
 
   /**
@@ -385,7 +365,7 @@ public class ChiliChicken implements Powerup {
    *          Can be True or False, stated on situation of player.
    */
   public void setAlive(Boolean bool) {
-    alive = bool;
+    wrapped.setAlive(bool);
   }
 
   /**
@@ -394,7 +374,7 @@ public class ChiliChicken implements Powerup {
    * @return Integer that represents the players number in the game.
    */
   public int getPlayerNumber() {
-    return id;
+    return wrapped.getPlayerNumber();
   }
 
   /**
@@ -404,7 +384,7 @@ public class ChiliChicken implements Powerup {
    *          Integer that represents the players number in the game.
    */
   public void setPlayerNumber(int id) {
-    this.id = id;
+    wrapped.setPlayerNumber(id);
   }
 
   /**
@@ -415,7 +395,7 @@ public class ChiliChicken implements Powerup {
    * @return Boolean.
    */
   public boolean hasAction(LevelElementAction action) {
-    return actions.contains(action);
+    return wrapped.hasAction(action);
   }
 
   /**
@@ -425,7 +405,7 @@ public class ChiliChicken implements Powerup {
    *          A LevelElementAction.
    */
   public void removeAction(LevelElementAction action) {
-    actions.remove(action);
+    wrapped.removeAction(action);
   }
 
   /**
@@ -434,7 +414,7 @@ public class ChiliChicken implements Powerup {
    * @return The last move performed.
    */
   public LevelElementAction getLastMove() {
-    return lastMove;
+    return wrapped.getLastMove();
   }
 
   /**
@@ -444,23 +424,17 @@ public class ChiliChicken implements Powerup {
    *          The last move action performed.
    */
   public void setLastMove(LevelElementAction action) {
-    if (action == LevelElementAction.MoveLeft || action == LevelElementAction.MoveRight) {
-      lastMove = action;
-    }
+    wrapped.setLastMove(action);
   }
 
   @Override
   public int hashCode() {
-    return 0;
+    return wrapped.hashCode();
   }
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof ChiliChicken) {
-      ChiliChicken that = (ChiliChicken) other;
-      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
-    }
-    return false;
+    return wrapped.equals(other);
   }
 
   /**
@@ -469,7 +443,7 @@ public class ChiliChicken implements Powerup {
    * @return whether the Player is firing
    */
   public Boolean isFiring() {
-    return firing;
+    return wrapped.isFiring();
   }
 
   /**
@@ -479,49 +453,16 @@ public class ChiliChicken implements Powerup {
    *          whether the Player is firing
    */
   public void setFiring(Boolean isFiring) {
-    this.firing = isFiring;
-  }
-
-  /**
-   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
-   * Element.
-   * 
-   * @param steps
-   *          The absolute exact number of steps since the game was started.
-   * @return Sprites to be drawn.
-   */
-  public ArrayList<Sprite> getSprites(double steps) {
-    ArrayList<Sprite> result = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    if (alive) {
-      boolean toRight = getLastMove() == LevelElementAction.MoveRight;
-
-      String id = "move-left";
-      if (firing && toRight) {
-        id = "shoot-right";
-      } else if (firing) {
-        id = "shoot-left";
-      } else if (toRight) {
-        id = "move-right";
-      }
-      if (getSpeed().getX() == 0 && !firing) {
-        steps = 0;
-      }
-
-      id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
-
-      result.add(store.getAnimated("fire-yellow").getFrame(steps));
-      result.add(store.getAnimated(id).getFrame(steps));
-      
-    }
-    return result;
+    wrapped.setFiring(isFiring);
   }
 
   /**
    * Gives a list of current actions of the player.
+   * 
    * @return a list of actions
    */
   public ArrayList<LevelElementAction> getActions() {
-    return actions;
+    return wrapped.getActions();
   }
+
 }

--- a/src/main/java/nl/tudelft/scrumbledore/powerup/PyroPepper.java
+++ b/src/main/java/nl/tudelft/scrumbledore/powerup/PyroPepper.java
@@ -2,10 +2,8 @@ package nl.tudelft.scrumbledore.powerup;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.level.DynamicElement;
 import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Player;
 import nl.tudelft.scrumbledore.level.LevelElementAction;
 import nl.tudelft.scrumbledore.level.Vector;
 import nl.tudelft.scrumbledore.sprite.Sprite;
@@ -19,34 +17,62 @@ import nl.tudelft.scrumbledore.sprite.SpriteStore;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public class PyroPepper implements Powerup {
-  private Vector position;
-  private Vector size;
-  private Vector speed;
-  private Vector friction;
-  private boolean gravity;
-  private ArrayList<LevelElementAction> actions;
-  private LevelElementAction lastMove;
-  private Boolean firing;
-  private Boolean alive;
-  private int id;
+
+  private DynamicElement wrapped;
 
   /**
    * Create a new LevelElement instance.
    * 
-   * @param player , the wrapped object.
+   * @param wrapped
+   *          The DynamicElement to be wrapped in this Powerup Decorator.
    */
-  public PyroPepper(DynamicElement player) {
-    this.position = player.getPosition();
-    this.size = player.getSize();
-    this.speed = player.getSpeed();
-    this.friction = new Vector(0, 0);
-    setGravity(true);
+  public PyroPepper(DynamicElement wrapped) {
+    this.wrapped = wrapped;
+  }
 
-    id = 0;
-    actions = player.getActions();
-    lastMove = player.getLastMove();
-    firing = player.isFiring();
-    alive = player.isAlive();
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    ArrayList<Sprite> sprites = new ArrayList<Sprite>();
+    SpriteStore store = SpriteStore.getInstance();
+    sprites.add(store.getAnimated("fire-red").getFrame(steps));
+    sprites.addAll(wrapped.getSprites(steps));
+    return sprites;
+  }
+
+  /**
+   * Decrease the lifetime by a given number of steps.
+   * 
+   * @param delta
+   *          The number of steps.
+   */
+  public void decreaseLifetime(double delta) {
+    wrapped.decreaseLifetime(delta);
+  }
+
+  /**
+   * Get the remaining lifetime.
+   * 
+   * @return Remaining lifetime.
+   */
+  public double getLifetime() {
+    return wrapped.getLifetime();
+  }
+
+  /**
+   * Setting the life time of a bubble.
+   * 
+   * @param newTime
+   *          The new life time.
+   */
+  public void setLifetime(double newTime) {
+    wrapped.setLifetime(newTime);
   }
 
   /**
@@ -55,7 +81,7 @@ public class PyroPepper implements Powerup {
    * @return Position Vector.
    */
   public Vector getPosition() {
-    return position;
+    return wrapped.getPosition();
   }
 
   /**
@@ -64,7 +90,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double posX() {
-    return position.getX();
+    return wrapped.posX();
   }
 
   /**
@@ -73,7 +99,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double posY() {
-    return position.getY();
+    return wrapped.posY();
   }
 
   /**
@@ -82,7 +108,7 @@ public class PyroPepper implements Powerup {
    * @return Size Vector.
    */
   public Vector getSize() {
-    return size;
+    return wrapped.getSize();
   }
 
   /**
@@ -91,7 +117,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double width() {
-    return size.getX();
+    return wrapped.width();
   }
 
   /**
@@ -100,7 +126,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double height() {
-    return size.getY();
+    return wrapped.height();
   }
 
   /**
@@ -109,7 +135,7 @@ public class PyroPepper implements Powerup {
    * @return Speed Vector.
    */
   public Vector getSpeed() {
-    return speed;
+    return wrapped.getSpeed();
   }
 
   /**
@@ -118,7 +144,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double hSpeed() {
-    return speed.getX();
+    return wrapped.hSpeed();
   }
 
   /**
@@ -127,7 +153,7 @@ public class PyroPepper implements Powerup {
    * @return double
    */
   public double vSpeed() {
-    return speed.getY();
+    return wrapped.vSpeed();
   }
 
   /**
@@ -136,7 +162,7 @@ public class PyroPepper implements Powerup {
    * @return Friction Vector.
    */
   public Vector getFriction() {
-    return friction;
+    return wrapped.getFriction();
   }
 
   /**
@@ -145,7 +171,7 @@ public class PyroPepper implements Powerup {
    * @return Horizontal friction.
    */
   public double hFric() {
-    return friction.getX();
+    return wrapped.hFric();
   }
 
   /**
@@ -154,21 +180,21 @@ public class PyroPepper implements Powerup {
    * @return Vertical friction.
    */
   public double vFric() {
-    return friction.getY();
+    return wrapped.vFric();
   }
 
   /**
    * Stop this LevelElement's vertical movement.
    */
   public void stopVertically() {
-    getSpeed().setY(0);
+    wrapped.stopVertically();
   }
 
   /**
    * Stop this LevelElement's horizontal movement.
    */
   public void stopHorizontally() {
-    getSpeed().setX(0);
+    wrapped.stopHorizontally();
   }
 
   /**
@@ -177,7 +203,7 @@ public class PyroPepper implements Powerup {
    * @return Boolean
    */
   public boolean hasGravity() {
-    return gravity;
+    return wrapped.hasGravity();
   }
 
   /**
@@ -187,7 +213,7 @@ public class PyroPepper implements Powerup {
    *          A boolean
    */
   public void setGravity(boolean gravity) {
-    this.gravity = gravity;
+    wrapped.setGravity(gravity);
   }
 
   /**
@@ -196,7 +222,7 @@ public class PyroPepper implements Powerup {
    * @return Y-coordinate of top.
    */
   public double getTop() {
-    return position.getY() - size.getY() / 2;
+    return wrapped.getTop();
   }
 
   /**
@@ -205,7 +231,7 @@ public class PyroPepper implements Powerup {
    * @return Y-coordinate of bottom.
    */
   public double getBottom() {
-    return position.getY() + size.getY() / 2;
+    return wrapped.getBottom();
   }
 
   /**
@@ -214,7 +240,7 @@ public class PyroPepper implements Powerup {
    * @return X-coordinate of left side.
    */
   public double getLeft() {
-    return position.getX() - size.getX() / 2;
+    return wrapped.getLeft();
   }
 
   /**
@@ -223,7 +249,7 @@ public class PyroPepper implements Powerup {
    * @return X-coordinate of right side.
    */
   public double getRight() {
-    return position.getX() + size.getX() / 2;
+    return wrapped.getRight();
   }
 
   /**
@@ -234,7 +260,7 @@ public class PyroPepper implements Powerup {
    * @return The distance.
    */
   public double distance(LevelElement other) {
-    return getPosition().distance(other.getPosition());
+    return wrapped.distance(other);
   }
 
   /**
@@ -248,7 +274,7 @@ public class PyroPepper implements Powerup {
    * @return A boolean.
    */
   public boolean inRadiusRangeOf(LevelElement other, double range) {
-    return distance(other) <= range;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -263,9 +289,7 @@ public class PyroPepper implements Powerup {
    * @return A boolean.
    */
   public boolean inBoxRangeOf(LevelElement other, double range) {
-    boolean inX = (other.posX() >= posX() - range && other.posX() <= posX() + range);
-    boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
-    return inX && inY;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -275,9 +299,7 @@ public class PyroPepper implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapLeft(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getLeft() - offset;
-    getPosition().setX(newPos);
+    wrapped.snapLeft(other);
   }
 
   /**
@@ -287,9 +309,7 @@ public class PyroPepper implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapRight(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getRight() + offset;
-    getPosition().setX(newPos);
+    wrapped.snapRight(other);
   }
 
   /**
@@ -299,9 +319,7 @@ public class PyroPepper implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapTop(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getTop() - offset;
-    getPosition().setY(newPos);
+    wrapped.snapTop(other);
   }
 
   /**
@@ -311,9 +329,7 @@ public class PyroPepper implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapBottom(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getBottom() + offset;
-    getPosition().setY(newPos);
+    wrapped.snapBottom(other);
   }
 
   /**
@@ -323,26 +339,23 @@ public class PyroPepper implements Powerup {
    *          A LevelElementAction
    */
   public void addAction(LevelElementAction action) {
-    if (!hasAction(action)) {
-      actions.add(action);
-      setLastMove(action);
-    }
+    wrapped.addAction(action);
   }
 
   /**
    * Remove all actions from the queue.
    */
   public void clearActions() {
-    actions.clear();
+    wrapped.clearActions();
   }
 
   /**
-   * Checking wether the player is alive.
+   * Checking whether the player is alive.
    * 
    * @return The boolean if the player is alive.
    */
   public Boolean isAlive() {
-    return alive;
+    return wrapped.isAlive();
   }
 
   /**
@@ -352,7 +365,7 @@ public class PyroPepper implements Powerup {
    *          Can be True or False, stated on situation of player.
    */
   public void setAlive(Boolean bool) {
-    alive = bool;
+    wrapped.setAlive(bool);
   }
 
   /**
@@ -361,7 +374,7 @@ public class PyroPepper implements Powerup {
    * @return Integer that represents the players number in the game.
    */
   public int getPlayerNumber() {
-    return id;
+    return wrapped.getPlayerNumber();
   }
 
   /**
@@ -371,7 +384,7 @@ public class PyroPepper implements Powerup {
    *          Integer that represents the players number in the game.
    */
   public void setPlayerNumber(int id) {
-    this.id = id;
+    wrapped.setPlayerNumber(id);
   }
 
   /**
@@ -382,7 +395,7 @@ public class PyroPepper implements Powerup {
    * @return Boolean.
    */
   public boolean hasAction(LevelElementAction action) {
-    return actions.contains(action);
+    return wrapped.hasAction(action);
   }
 
   /**
@@ -392,7 +405,7 @@ public class PyroPepper implements Powerup {
    *          A LevelElementAction.
    */
   public void removeAction(LevelElementAction action) {
-    actions.remove(action);
+    wrapped.removeAction(action);
   }
 
   /**
@@ -401,7 +414,7 @@ public class PyroPepper implements Powerup {
    * @return The last move performed.
    */
   public LevelElementAction getLastMove() {
-    return lastMove;
+    return wrapped.getLastMove();
   }
 
   /**
@@ -411,24 +424,17 @@ public class PyroPepper implements Powerup {
    *          The last move action performed.
    */
   public void setLastMove(LevelElementAction action) {
-    if (action == LevelElementAction.MoveLeft || action == LevelElementAction.MoveRight) {
-      lastMove = action;
-    }
+    wrapped.setLastMove(action);
   }
 
   @Override
   public int hashCode() {
-    return 0;
+    return wrapped.hashCode();
   }
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof PyroPepper) {
-      PyroPepper that = (PyroPepper) other;
-      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
-    }
-
-    return false;
+    return wrapped.equals(other);
   }
 
   /**
@@ -437,7 +443,7 @@ public class PyroPepper implements Powerup {
    * @return whether the Player is firing
    */
   public Boolean isFiring() {
-    return firing;
+    return wrapped.isFiring();
   }
 
   /**
@@ -447,76 +453,16 @@ public class PyroPepper implements Powerup {
    *          whether the Player is firing
    */
   public void setFiring(Boolean isFiring) {
-    this.firing = isFiring;
-  }
-
-  /**
-   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
-   * Element.
-   * 
-   * @param steps
-   *          The absolute exact number of steps since the game was started.
-   * @return Sprites to be drawn.
-   */
-  public ArrayList<Sprite> getSprites(double steps) {
-    ArrayList<Sprite> result = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    if (alive) {
-      boolean toRight = getLastMove() == LevelElementAction.MoveRight;
-
-      String id = "move-left";
-      if (firing && toRight) {
-        id = "shoot-right";
-      } else if (firing) {
-        id = "shoot-left";
-      } else if (toRight) {
-        id = "move-right";
-      }
-      if (getSpeed().getX() == 0 && !firing) {
-        steps = 0;
-      }
-
-      id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
-
-      result.add(store.getAnimated("fire-red").getFrame(steps));
-      result.add(store.getAnimated(id).getFrame(steps));
-    }
-    return result;
+    wrapped.setFiring(isFiring);
   }
 
   /**
    * Gives a list of current actions of the player.
+   * 
    * @return a list of actions
    */
   public ArrayList<LevelElementAction> getActions() {
-    return actions;
-  }
-  
-  /**
-   * Decrease the lifetime by a given number of steps.
-   * 
-   * @param delta
-   *          The number of steps.
-   */
-  public void decreaseLifetime(double delta) {
-  }
-
-  /**
-   * Get the remaining lifetime.
-   * 
-   * @return Remaining lifetime.
-   */
-  public double getLifetime() {
-    return 0;
-  }
-
-  /**
-   * Setting the life time of a bubble.
-   * 
-   * @param newTime
-   *          The new life time.
-   */
-  public void setLifetime(double newTime) {
+    return wrapped.getActions();
   }
 
 }

--- a/src/main/java/nl/tudelft/scrumbledore/powerup/TurtleTaco.java
+++ b/src/main/java/nl/tudelft/scrumbledore/powerup/TurtleTaco.java
@@ -2,10 +2,8 @@ package nl.tudelft.scrumbledore.powerup;
 
 import java.util.ArrayList;
 
-import nl.tudelft.scrumbledore.Constants;
 import nl.tudelft.scrumbledore.level.DynamicElement;
 import nl.tudelft.scrumbledore.level.LevelElement;
-import nl.tudelft.scrumbledore.level.Player;
 import nl.tudelft.scrumbledore.level.LevelElementAction;
 import nl.tudelft.scrumbledore.level.Vector;
 import nl.tudelft.scrumbledore.sprite.Sprite;
@@ -20,36 +18,61 @@ import nl.tudelft.scrumbledore.sprite.SpriteStore;
 @SuppressWarnings("PMD.TooManyMethods")
 public class TurtleTaco implements Powerup {
 
-  private Vector position;
-  private Vector size;
-  private Vector speed;
-  private Vector friction;
-  private boolean gravity;
-  private ArrayList<LevelElementAction> actions;
-  private LevelElementAction lastMove;
-  private Boolean firing;
-  private Boolean alive;
-  private int id;
-  private double lifetime;
+  private DynamicElement wrapped;
 
   /**
    * Create a new LevelElement instance.
    * 
-   * @param player , the wrapped object.
+   * @param wrapped
+   *          The DynamicElement to be wrapped in this Powerup Decorator.
    */
-  public TurtleTaco(DynamicElement player) {
-    this.position = player.getPosition();
-    this.size = player.getSize();
-    this.speed = player.getSpeed();
-    this.friction = new Vector(0, 0);
-    setGravity(true);
+  public TurtleTaco(DynamicElement wrapped) {
+    this.wrapped = wrapped;
+  }
 
-    id = 0;
-    actions = player.getActions();
-    lastMove = player.getLastMove();
-    firing = player.isFiring();
-    alive = player.isAlive();
-    lifetime = Constants.TURTLE_LIFETIME;
+  /**
+   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
+   * Element.
+   * 
+   * @param steps
+   *          The absolute exact number of steps since the game was started.
+   * @return Sprites to be drawn.
+   */
+  public ArrayList<Sprite> getSprites(double steps) {
+    ArrayList<Sprite> sprites = new ArrayList<Sprite>();
+    SpriteStore store = SpriteStore.getInstance();
+    sprites.add(store.getAnimated("fire-green").getFrame(steps));
+    sprites.addAll(wrapped.getSprites(steps));
+    return sprites;
+  }
+
+  /**
+   * Decrease the lifetime by a given number of steps.
+   * 
+   * @param delta
+   *          The number of steps.
+   */
+  public void decreaseLifetime(double delta) {
+    wrapped.decreaseLifetime(delta);
+  }
+
+  /**
+   * Get the remaining lifetime.
+   * 
+   * @return Remaining lifetime.
+   */
+  public double getLifetime() {
+    return wrapped.getLifetime();
+  }
+
+  /**
+   * Setting the life time of a bubble.
+   * 
+   * @param newTime
+   *          The new life time.
+   */
+  public void setLifetime(double newTime) {
+    wrapped.setLifetime(newTime);
   }
 
   /**
@@ -58,7 +81,7 @@ public class TurtleTaco implements Powerup {
    * @return Position Vector.
    */
   public Vector getPosition() {
-    return position;
+    return wrapped.getPosition();
   }
 
   /**
@@ -67,7 +90,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double posX() {
-    return position.getX();
+    return wrapped.posX();
   }
 
   /**
@@ -76,7 +99,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double posY() {
-    return position.getY();
+    return wrapped.posY();
   }
 
   /**
@@ -85,7 +108,7 @@ public class TurtleTaco implements Powerup {
    * @return Size Vector.
    */
   public Vector getSize() {
-    return size;
+    return wrapped.getSize();
   }
 
   /**
@@ -94,7 +117,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double width() {
-    return size.getX();
+    return wrapped.width();
   }
 
   /**
@@ -103,7 +126,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double height() {
-    return size.getY();
+    return wrapped.height();
   }
 
   /**
@@ -112,7 +135,7 @@ public class TurtleTaco implements Powerup {
    * @return Speed Vector.
    */
   public Vector getSpeed() {
-    return speed;
+    return wrapped.getSpeed();
   }
 
   /**
@@ -121,7 +144,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double hSpeed() {
-    return speed.getX();
+    return wrapped.hSpeed();
   }
 
   /**
@@ -130,7 +153,7 @@ public class TurtleTaco implements Powerup {
    * @return double
    */
   public double vSpeed() {
-    return speed.getY();
+    return wrapped.vSpeed();
   }
 
   /**
@@ -139,7 +162,7 @@ public class TurtleTaco implements Powerup {
    * @return Friction Vector.
    */
   public Vector getFriction() {
-    return friction;
+    return wrapped.getFriction();
   }
 
   /**
@@ -148,7 +171,7 @@ public class TurtleTaco implements Powerup {
    * @return Horizontal friction.
    */
   public double hFric() {
-    return friction.getX();
+    return wrapped.hFric();
   }
 
   /**
@@ -157,21 +180,21 @@ public class TurtleTaco implements Powerup {
    * @return Vertical friction.
    */
   public double vFric() {
-    return friction.getY();
+    return wrapped.vFric();
   }
 
   /**
    * Stop this LevelElement's vertical movement.
    */
   public void stopVertically() {
-    getSpeed().setY(0);
+    wrapped.stopVertically();
   }
 
   /**
    * Stop this LevelElement's horizontal movement.
    */
   public void stopHorizontally() {
-    getSpeed().setX(0);
+    wrapped.stopHorizontally();
   }
 
   /**
@@ -180,7 +203,7 @@ public class TurtleTaco implements Powerup {
    * @return Boolean
    */
   public boolean hasGravity() {
-    return gravity;
+    return wrapped.hasGravity();
   }
 
   /**
@@ -190,7 +213,7 @@ public class TurtleTaco implements Powerup {
    *          A boolean
    */
   public void setGravity(boolean gravity) {
-    this.gravity = gravity;
+    wrapped.setGravity(gravity);
   }
 
   /**
@@ -199,7 +222,7 @@ public class TurtleTaco implements Powerup {
    * @return Y-coordinate of top.
    */
   public double getTop() {
-    return position.getY() - size.getY() / 2;
+    return wrapped.getTop();
   }
 
   /**
@@ -208,7 +231,7 @@ public class TurtleTaco implements Powerup {
    * @return Y-coordinate of bottom.
    */
   public double getBottom() {
-    return position.getY() + size.getY() / 2;
+    return wrapped.getBottom();
   }
 
   /**
@@ -217,7 +240,7 @@ public class TurtleTaco implements Powerup {
    * @return X-coordinate of left side.
    */
   public double getLeft() {
-    return position.getX() - size.getX() / 2;
+    return wrapped.getLeft();
   }
 
   /**
@@ -226,7 +249,7 @@ public class TurtleTaco implements Powerup {
    * @return X-coordinate of right side.
    */
   public double getRight() {
-    return position.getX() + size.getX() / 2;
+    return wrapped.getRight();
   }
 
   /**
@@ -237,7 +260,7 @@ public class TurtleTaco implements Powerup {
    * @return The distance.
    */
   public double distance(LevelElement other) {
-    return getPosition().distance(other.getPosition());
+    return wrapped.distance(other);
   }
 
   /**
@@ -251,7 +274,7 @@ public class TurtleTaco implements Powerup {
    * @return A boolean.
    */
   public boolean inRadiusRangeOf(LevelElement other, double range) {
-    return distance(other) <= range;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -266,9 +289,7 @@ public class TurtleTaco implements Powerup {
    * @return A boolean.
    */
   public boolean inBoxRangeOf(LevelElement other, double range) {
-    boolean inX = (other.posX() >= posX() - range && other.posX() <= posX() + range);
-    boolean inY = (other.posY() >= posY() - range && other.posY() <= posY() + range);
-    return inX && inY;
+    return wrapped.inBoxRangeOf(other, range);
   }
 
   /**
@@ -278,9 +299,7 @@ public class TurtleTaco implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapLeft(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getLeft() - offset;
-    getPosition().setX(newPos);
+    wrapped.snapLeft(other);
   }
 
   /**
@@ -290,9 +309,7 @@ public class TurtleTaco implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapRight(LevelElement other) {
-    double offset = getSize().getX() / 2;
-    double newPos = other.getRight() + offset;
-    getPosition().setX(newPos);
+    wrapped.snapRight(other);
   }
 
   /**
@@ -302,9 +319,7 @@ public class TurtleTaco implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapTop(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getTop() - offset;
-    getPosition().setY(newPos);
+    wrapped.snapTop(other);
   }
 
   /**
@@ -314,9 +329,7 @@ public class TurtleTaco implements Powerup {
    *          The LevelElement to be snapped to.
    */
   public void snapBottom(LevelElement other) {
-    double offset = getSize().getY() / 2;
-    double newPos = other.getBottom() + offset;
-    getPosition().setY(newPos);
+    wrapped.snapBottom(other);
   }
 
   /**
@@ -326,26 +339,23 @@ public class TurtleTaco implements Powerup {
    *          A LevelElementAction
    */
   public void addAction(LevelElementAction action) {
-    if (!hasAction(action)) {
-      actions.add(action);
-      setLastMove(action);
-    }
+    wrapped.addAction(action);
   }
 
   /**
    * Remove all actions from the queue.
    */
   public void clearActions() {
-    actions.clear();
+    wrapped.clearActions();
   }
 
   /**
-   * Checking wether the player is alive.
+   * Checking whether the player is alive.
    * 
    * @return The boolean if the player is alive.
    */
   public Boolean isAlive() {
-    return alive;
+    return wrapped.isAlive();
   }
 
   /**
@@ -355,7 +365,7 @@ public class TurtleTaco implements Powerup {
    *          Can be True or False, stated on situation of player.
    */
   public void setAlive(Boolean bool) {
-    alive = bool;
+    wrapped.setAlive(bool);
   }
 
   /**
@@ -364,7 +374,7 @@ public class TurtleTaco implements Powerup {
    * @return Integer that represents the players number in the game.
    */
   public int getPlayerNumber() {
-    return id;
+    return wrapped.getPlayerNumber();
   }
 
   /**
@@ -374,7 +384,7 @@ public class TurtleTaco implements Powerup {
    *          Integer that represents the players number in the game.
    */
   public void setPlayerNumber(int id) {
-    this.id = id;
+    wrapped.setPlayerNumber(id);
   }
 
   /**
@@ -385,7 +395,7 @@ public class TurtleTaco implements Powerup {
    * @return Boolean.
    */
   public boolean hasAction(LevelElementAction action) {
-    return actions.contains(action);
+    return wrapped.hasAction(action);
   }
 
   /**
@@ -395,7 +405,7 @@ public class TurtleTaco implements Powerup {
    *          A LevelElementAction.
    */
   public void removeAction(LevelElementAction action) {
-    actions.remove(action);
+    wrapped.removeAction(action);
   }
 
   /**
@@ -404,7 +414,7 @@ public class TurtleTaco implements Powerup {
    * @return The last move performed.
    */
   public LevelElementAction getLastMove() {
-    return lastMove;
+    return wrapped.getLastMove();
   }
 
   /**
@@ -414,24 +424,17 @@ public class TurtleTaco implements Powerup {
    *          The last move action performed.
    */
   public void setLastMove(LevelElementAction action) {
-    if (action == LevelElementAction.MoveLeft || action == LevelElementAction.MoveRight) {
-      lastMove = action;
-    }
+    wrapped.setLastMove(action);
   }
 
   @Override
   public int hashCode() {
-    return 0;
+    return wrapped.hashCode();
   }
 
   @Override
   public boolean equals(Object other) {
-    if (other instanceof TurtleTaco) {
-      TurtleTaco that = (TurtleTaco) other;
-      return this.getPosition().equals(that.getPosition()) && this.getSize().equals(that.getSize());
-    }
-
-    return false;
+    return wrapped.equals(other);
   }
 
   /**
@@ -440,7 +443,7 @@ public class TurtleTaco implements Powerup {
    * @return whether the Player is firing
    */
   public Boolean isFiring() {
-    return firing;
+    return wrapped.isFiring();
   }
 
   /**
@@ -450,78 +453,16 @@ public class TurtleTaco implements Powerup {
    *          whether the Player is firing
    */
   public void setFiring(Boolean isFiring) {
-    this.firing = isFiring;
-  }
-
-  /**
-   * Retrieve a set of Sprites to be drawn in the current cycle at the position of this Level
-   * Element.
-   * 
-   * @param steps
-   *          The absolute exact number of steps since the game was started.
-   * @return Sprites to be drawn.
-   */
-  public ArrayList<Sprite> getSprites(double steps) {
-    ArrayList<Sprite> result = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    if (alive) {
-      boolean toRight = getLastMove() == LevelElementAction.MoveRight;
-
-      String id = "move-left";
-      if (firing && toRight) {
-        id = "shoot-right";
-      } else if (firing) {
-        id = "shoot-left";
-      } else if (toRight) {
-        id = "move-right";
-      }
-      if (getSpeed().getX() == 0 && !firing) {
-        steps = 0;
-      }
-
-      id = "player-" + Constants.PLAYER_COLORS.get(getPlayerNumber()) + "-" + id;
-
-      result.add(store.getAnimated("fire-green").getFrame(steps));
-      result.add(store.getAnimated(id).getFrame(steps));
-    }
-    return result;
+    wrapped.setFiring(isFiring);
   }
 
   /**
    * Gives a list of current actions of the player.
+   * 
    * @return a list of actions
    */
   public ArrayList<LevelElementAction> getActions() {
-    return actions;
-  }
-  
-  /**
-   * Decrease the lifetime by a given number of steps.
-   * 
-   * @param delta
-   *          The number of steps.
-   */
-  public void decreaseLifetime(double delta) {
-    lifetime -= delta;
-  }
-
-  /**
-   * Get the remaining lifetime.
-   * 
-   * @return Remaining lifetime.
-   */
-  public double getLifetime() {
-    return lifetime;
-  }
-
-  /**
-   * Setting the life time of a bubble.
-   * 
-   * @param newTime
-   *          The new life time.
-   */
-  public void setLifetime(double newTime) {
-    lifetime = newTime;
+    return wrapped.getActions();
   }
 
 }


### PR DESCRIPTION
Refactored the powerup classes to conform properly to the Decorator Design
Pattern. They wrap a DynamicElement instance and call it's methods so the
Decorator is wrapping the element instead of copying. Powerups can now
also stack properly.

Relates to Issue #223.

<organisation