### PR TITLE
Fix settings displacement

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
+++ b/src/main/java/nl/tudelft/scrumbledore/userinterface/GameDisplay.java
@@ -263,7 +263,7 @@ public final class GameDisplay {
       if (endStepsSnapShot == 0) {
         advanceLabel = Constants.ADVANCINGLABEL;
         staticContext.setFill(Color.WHITE);
-        staticContext.fillText(advanceLabel, (Constants.LEVELX / 2) - 100,
+        staticContext.fillText(advanceLabel, (Constants.LEVELX / 2) - 110,
             (Constants.LEVELY / 2) - 130);
         endStepsSnapShot = currentGame.getSteps();
       }

--- a/src/main/resources/css/settingsstyle.css
+++ b/src/main/resources/css/settingsstyle.css
@@ -67,7 +67,7 @@
  	-fx-text-fill: #1d1d1d;
  	-fx-font-weight: bold;
  	-fx-font-size: 15.0px;
- 	-fx-padding: 0.5 0.0 0.5 0.5;
+ 	-fx-padding: 5.0 0.0 5.0 0.5;
  	-fx-border-style: solid;
 	-fx-border-color: #333333;
  	-fx-border-width: 1.0 0.0 1.0 0.0;

--- a/src/main/resources/css/settingsstyle.css
+++ b/src/main/resources/css/settingsstyle.css
@@ -67,7 +67,7 @@
  	-fx-text-fill: #1d1d1d;
  	-fx-font-weight: bold;
  	-fx-font-size: 15.0px;
- 	-fx-padding: 5.0 0.0 5.0 0.5;
+ 	-fx-padding: 5.0 2.5 5.0 2.5;
  	-fx-border-style: solid;
 	-fx-border-color: #333333;
  	-fx-border-width: 1.0 0.0 1.0 0.0;


### PR DESCRIPTION
-Fixed the issue that caused the settings bar to displace randomly after choosing an option.
-Fixed the issue that caused the settings bar to collapse entirely after choosing the last keybinding options.
-Added some extra horiztonal padding to the settings bar to ensure that it looks more pleasing to the eye.
-Fixed the coordinates to ensure that the level advancement label actually is centered based on the string length.