### PR TITLE
Add isAlive check to fix rendering bug

### DIFF
--- a/src/main/java/nl/tudelft/scrumbledore/level/powerup/ChiliChicken.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/powerup/ChiliChicken.java
@@ -39,9 +39,12 @@ public class ChiliChicken implements PlayerElement {
    */
   public ArrayList<Sprite> getSprites(double steps) {
     ArrayList<Sprite> sprites = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    sprites.add(store.getAnimated("fire-yellow").getFrame(steps));
-    sprites.addAll(wrapped.getSprites(steps));
+    
+    if (isAlive()) {
+      SpriteStore store = SpriteStore.getInstance();
+      sprites.add(store.getAnimated("fire-yellow").getFrame(steps));
+      sprites.addAll(wrapped.getSprites(steps));
+    }
     return sprites;
   }
 

--- a/src/main/java/nl/tudelft/scrumbledore/level/powerup/TurtleTaco.java
+++ b/src/main/java/nl/tudelft/scrumbledore/level/powerup/TurtleTaco.java
@@ -39,9 +39,13 @@ public class TurtleTaco implements PlayerElement {
    */
   public ArrayList<Sprite> getSprites(double steps) {
     ArrayList<Sprite> sprites = new ArrayList<Sprite>();
-    SpriteStore store = SpriteStore.getInstance();
-    sprites.add(store.getAnimated("fire-green").getFrame(steps));
-    sprites.addAll(wrapped.getSprites(steps));
+    
+    if (isAlive()) {
+      SpriteStore store = SpriteStore.getInstance();
+      sprites.add(store.getAnimated("fire-green").getFrame(steps));
+      sprites.addAll(wrapped.getSprites(steps));
+    }
+    
     return sprites;
   }
 


### PR DESCRIPTION
Fix the powerup animation rendering bug by adding additional validation to make sure that rendering only happens when a player is alive.

Issue: #278 
<bug